### PR TITLE
Reject HTLC if amount is below dust-limit-satoshis.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -413,8 +413,7 @@ estimate of cost of inclusion in a block.
 
 The sender MUST set `signature` to the bitcoin signature of the close
 transaction with the node responsible for paying the bitcoin fee
-paying `fee-satoshis`, without populating any output which is below
-the receiver's `dust-limit-satoshis`.
+paying `fee-satoshis`.
 
 The receiver MUST check `signature` is valid for the close transaction
 with the given `fee-satoshis` as detailed above, and MUST fail the

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -32,7 +32,7 @@ commitment transaction.
 
 ### Commitment Transaction Outputs
 
-The amounts for each output are rounded down to whole satoshis.  If this amount is less than the `dust-limit-satoshis` set by the owner of the commitment transaction, the output is not produced (thus the funds add to fees).
+The amounts for each output are rounded down to whole satoshis.  If this amount is less than the `dust-limit-satoshis` set by the owner of the commitment transaction, the `HTLC` SHOULD be rejected.
 
 To allow an opportunity for penalty transactions in case of a revoked commitment transaction, all outputs which return funds to the owner of the commitment transaction (aka "local node") must be delayed for `to-self-delay` blocks.  This delay is done in a second stage HTLC transaction.
 


### PR DESCRIPTION
Hi all! At the Lightning Summit in Milan you agreed on a mechanism to allow sub-dust `HTLC's` on the network. But one of the drawbacks of such decision might be the case when attacker (`Alice #1`) sends a lots of dust `HTLCs` over some intermediary node (`Carol`) to himself (`Alice #2`). In this case if `dust-limit-satoshis` in channel `Alice #1 => Carol` lower than `dust-limit-satoshis` in channel `Carol => Alice #2`, attacker might turn all `bitcoins` in channel `Carol => Alice #2` to miners fee without any consequences for himself. 

In this case we may add additional field `max_num_dust_htlcs` and after exceeding this number we still should reject sub-dust `HTLCs`. So, for me it looks like it would be better to just reject `HTLCs` below dust limit. 

Is accepting dust `HTLCs` is something that end user really needs in first version? I mean as far as I know dust limit in `Bitcoin` is `5460 sat` which is `5460 sat / 10^8 sat * 746$ = 0,041$` which is pretty low amount. Sorry if that was already discussed :)