### PR TITLE
BOLT 2: fix funding_locked announcement signatures.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -231,8 +231,9 @@ This message indicates that the funding transaction has reached the `minimum-dep
 2. data:
 	* [8:temporary-channel-id]
     * [8:channel-id]
+    * [64:announcement-node-signature]
+    * [64:announcement-bitcoin-signature]
     * [33:next-per-commitment-point]
-    * [33:announcement-signature]
 
 The `channel-id` is the unique description of the funding transaction.
 It is constructed with the most significant 3 bytes as the block
@@ -243,7 +244,7 @@ index which pays to the channel.
 This `channel-id` is used in all messages referring to the channel
 from this point onwards.
 
-`announcement-signature` is the optional signature for `channel_announcement` as described in [BOLT #7](07-routing-gossip.md#the-channel_announcement-message).
+`announcement-node-signature` and `announcement-bitcoin-signature` are the optional signature for `channel_announcement` as described in [BOLT #7](07-routing-gossip.md#the-channel_announcement-message).
 
 #### Requirements
 
@@ -260,12 +261,13 @@ transaction, derived as specified in
 If the recipient has already sent `funding_locked` it MUST fail the
 channel if `channel-id` does not match the `channel-id` it sent.
 
-The sender MUST set `announcement-signature` to the signature for the
-channel_announcement message, or all zeroes if it does not want the
+The sender MUST set `announcement-node-signature` and `announcement-bitcoin-signature` to the signatures for the
+`channel_announcement` message, or all zeroes if it does not want the
 channel announced.
 
+The recipient SHOULD fail the channel if the `announcement-node-signature` and `announcement-bitcoin-signature`s are incorrect (and not all zeroes).
 The recipient SHOULD queue the `channel_announcement` message for its
-peers if it has sent and received a non-zero `announcement-signature`.
+peers if it has sent and received a non-zero `announcement-node-signature` and `announcement-bitcoin-signature`.
 
 #### Future
 


### PR DESCRIPTION
We need to supply a pair (a signature using our bitcoin key which signs the
node id, and a signature using our node key which signs the announce message),
and the length was wrong.  Move them to make alignment nicer, too (though
it probably doesn't matter, they're 4-byte aligned everywhere else).