### PR TITLE
[RFC] BOLT 1, BOLT 2, BOLT 5: 2-byte lengths everywhere.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -77,9 +77,9 @@ desire to set up a new channel.
    * [8:max-htlc-value-in-flight-msat]
    * [8:channel-reserve-satoshis]
    * [4:htlc-minimum-msat]
-   * [4:max-accepted-htlcs]
    * [4:feerate-per-kw]
    * [2:to-self-delay]
+   * [2:max-accepted-htlcs]
    * [33:funding-pubkey]
    * [33:revocation-basepoint]
    * [33:payment-basepoint]
@@ -117,9 +117,7 @@ immediately included in a block.
 
 The sender SHOULD set `dust-limit-satoshis` to sufficient value to
 allow commitment transactions to propagate through the bitcoin
-network.  It MUST set `max-accepted-htlcs` to less than or equal to 600
-<sup>[BOLT #5](05-onchain.md#penalty-transaction-weight-calculation)</sup>.
-It SHOULD set `htlc-minimum-msat` to the minimum
+network.  It SHOULD set `htlc-minimum-msat` to the minimum
 amount HTLC it is willing to accept from this peer.
 
 
@@ -128,8 +126,7 @@ unreasonably large.  The receiver MAY fail the channel if
 `funding-satoshis` is too small, and MUST fail the channel if
 `push-msat` is greater than `funding-amount` * 1000.
 The receiving node MAY fail the channel if it considers
-`htlc-minimum-msat` too large, `max-htlc-value-in-flight` too small, `channel-reserve-satoshis` too large, or `max-accepted-htlcs` too small.  It MUST fail the channel if `max-accepted-htlcs` is greater than 600.
-
+`htlc-minimum-msat` too large, `max-htlc-value-in-flight` too small, `channel-reserve-satoshis` too large, or `max-accepted-htlcs` too small.  It MUST fail the channel if `max-accepted-htlcs` is greater than 511.
 
 The receiver MUST fail the channel if
 considers `feerate-per-kw` too small for timely processing, or unreasonably large.  The
@@ -173,8 +170,8 @@ acceptance of the new channel.
    * [8:channel-reserve-satoshis]
    * [4:minimum-depth]
    * [4:htlc-minimum-msat]
-   * [4:max-accpted-htlcs]
    * [2:to-self-delay]
+   * [2:max-accepted-htlcs]
    * [33:funding-pubkey]
    * [33:revocation-basepoint]
    * [33:payment-basepoint]
@@ -379,7 +376,7 @@ and indicating the scriptpubkey it wants to be paid to.
 1. type: 38 (`shutdown`)
 2. data:
    * [8:channel-id]
-   * [4:len]
+   * [2:len]
    * [len:scriptpubkey]
 
 #### Requirements
@@ -616,6 +613,11 @@ Retransmissions of unacknowledged updates are explicitly allowed for
 reconnection purposes; allowing them at other times simplifies the
 recipient code, though strict checking may help debugging.
 
+`max-accepted-htlcs` is limited to 511, to ensure that even if both
+sides send the maximum number of HTLCs, the `commit_sig` message will
+still be under the maximum message size.  It also ensures that
+a single penalty transaction can spend the entire commitment transaction,
+as calculated in [BOLT #5](05-onchain.md#penalty-transaction-weight-calculation).
 
 ### Removing an HTLC: `update_fulfill_htlc` and `update_fail_htlc`
 
@@ -677,7 +679,7 @@ sign the resulting transaction as defined in [BOLT #3] and send a
 2. data:
    * [8:channel-id]
    * [64:signature]
-   * [4:num-htlcs]
+   * [2:num-htlcs]
    * [num-htlcs*64:htlc-signature]
 
 #### Requirements
@@ -734,7 +736,7 @@ The description of key derivation is in [BOLT #3](03-transactions.md#key-derivat
    * [32:per-commitment-secret]
    * [33:next-per-commitment-point]
    * [3:padding]
-   * [4:num-htlc-timeouts]
+   * [2:num-htlc-timeouts]
    * [num-htlc-timeouts*64:htlc-timeout-signature]
 
 #### Requirements

--- a/05-onchain.md
+++ b/05-onchain.md
@@ -307,9 +307,8 @@ The node MAY use a single transaction to *resolve* all the outputs, but MUST han
 
 
 A single transaction which resolves all the outputs will be under the
-standard size limit thanks to the [FIXME] HTLC-per-party limit (See
-BOLT #2: FIXME).
-
+standard size limit thanks to the 511 HTLC-per-party limit (see
+[BOLT #2](02-peer-protocol.md#the-open_channel-message)).
 
 Note that if a single transaction is used, it may be invalidated as B
 broadcasts HTLC-timeout and HTLC-success transactions, but the


### PR DESCRIPTION
Since our cryptopacket limits us to 2 bytes, and since people will send 1-message-per-crypto-packet and nobody will test the multiple-messages-in-one-cryptopacket code, let's just restrict to 64k messages.

1. Make cryptopacket length not include the HMAC, so we can actually send
   64k messages.
2. Remove len prefix from packet, add padding to restore alignment.
3. Change message internal lengths/counts from 4 to 2 bytes, since more
   is nonsensical anyway, and this removes a need to check before allocating:
    - init feature bitfield length
    - error message length
    - shutdown scriptpubkey length
    - commit_sig number of HTLC signatures
    - revoke_and_ack number of HTLC-timeout signatures
4. Also change max-num-htlcs to a single byte, which ensures that commit_sig
   will always be under 64k (max around 32k).