### PR TITLE
Adding a first-per-commitment-point field to open_channel

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -84,6 +84,7 @@ desire to set up a new channel.
    * [33:revocation-basepoint]
    * [33:payment-basepoint]
    * [33:delayed-payment-basepoint]
+   * [33:first-per-commitment-point]
 
 
 The `temporary-channel-id` is used to identify this channel until the funding transaction is established.  `funding-satoshis` is the amount the sender is putting into the channel.  `dust-limit-satoshis` is the threshold below which output should be generated for this node’s commitment or HTLC transaction; ie. HTLCs below this amount plus HTLC transaction fess are not enforceable onchain.  This reflects the reality that tiny outputs are not considered standard transactions and will not propagate through the bitcoin network.


### PR DESCRIPTION
```
   A                                B
   |                                |
   |       (1) open_channel         |
   |------------------------------->|
   |                                |
   |       (2) accept_channel       |
   |<-------------------------------|
   |                                |
   |      (3) funding_created       |
   |------------------------------->|
   |                                |
   |       (4) funding_signed       |
   |<-------------------------------|
```
B needs A's `first-per-commitment-point` to compute the signature that B is supposed to return in step (4).

On a related note, I am not sure why A includes his signature in `funding_created`. At first I thought the reason for this is that the first commitment transaction can pay both parties, because of the possibility to have a `pushMsat` > 0. But on second thought I don't think B needs to have it: as soon as the funding tx is published, the only tx that can spend it is A's first commitment tx, which does pay `pushMsat` to B. Sure if A disappears, then B will never get his money, but should he get paid if nothing ever happened in the channel? I guess that depends on the rationale behind `pushMsat`?