### PR TITLE
BOLT 2: remove attempts to align signatures.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -198,7 +198,6 @@ signature, it will broadcast the funding transaction.
     * [8:temporary-channel-id]
     * [32:txid]
     * [1:output-index]
-    * [1:pad]
     * [64:signature]
 
 #### Requirements
@@ -735,7 +734,7 @@ The description of key derivation is in [BOLT #3](03-transactions.md#key-derivat
    * [8:channel-id]
    * [32:per-commitment-secret]
    * [33:next-per-commitment-point]
-   * [3:padding]
+   * [1:padding]
    * [2:num-htlc-timeouts]
    * [num-htlc-timeouts*64:htlc-timeout-signature]
 

--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -15,7 +15,7 @@ def guess_alignment(message,name,sizestr):
     # - channel-id is size 8, but has alignment 4.
     # - node_announcement.ipv6 has size 16, but alignment 4 (to align IPv4 addr).
     # - node_announcement.alias is a string, so alignment 1
-    # - signatures have alignment 4, because why not.
+    # - signatures have no alignment requirement.
     if match.group('name').startswith('pad'):
         return 1
 
@@ -29,7 +29,7 @@ def guess_alignment(message,name,sizestr):
         return 1
 
     if 'signature' in match.group('name'):
-       return 4
+       return 1
     
     # Size can be variable.
     try:


### PR DESCRIPTION
They're really a blob of bytes, and we weren't aligning them correctly in
two cases anyway.  This gets rid of gratuitous padding, too.