### PR TITLE
onion: Specifying `payment-key` commitment in onion

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -539,6 +539,9 @@ reconnection if it has the sender did not previously acknowledge the
 commitment of that HTLC.  A receiving node MAY fail the channel if
 other `id` violations occur.
 
+The `onion-routing-packet` contains an obfuscated list of hops and instructions for each hop along the path.
+It commits to the HTLC by setting the `payment-key` as associated data, i.e., including the `payment-key` in the computation of HMACs.
+This prevents replay attacks that'd reuse a previous `onion-routing-packet` with a different `payment-key`.
 
 #### Rationale
 


### PR DESCRIPTION
Specifying that the `onion-routing-packet` commits to the
`payment-key` by setting the associated data. This avoids replay
attacks and specifying it here keeps the onion-routing spec clean.