### PR TITLE
BOLT 4, BOLT 8: use libsecp256k1-style ECDH.

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -310,9 +310,9 @@ In the packet generation phase the secret is the `sessionkey` and the public key
 In the pocessing phase the secret is the node's private key and the public key is the ephemeral public key from the packet, which has been incrementally blinded by the predecessors.
 
 The public key is multiplied by the secret, using to the `secp256k1` curve.
-The `X` coordinate of the multiplication result is serialized and hashed using `SHA256`.
+The DER compressed representation of the multiplication result is serialized and hashed using `SHA256`.
 The resulting hash is returned as the shared secret.
-Notice that this is not the ECDH variant implemented in `libsecp256k1` which also includes the `Y` coordinate in the hash.
+Notice that this is the ECDH variant implemented in `libsecp256k1`.
 
 ## Filler Generation
 

--- a/08-transport.md
+++ b/08-transport.md
@@ -127,8 +127,8 @@ The following functions will also be referenced:
   * `ECDH(rk, k)`: Performs an Elliptic-Curve Diffie-Hellman operation using
     `rk` which is a `secp256k1` public key and `k` which is a valid private key
     within the finite field as defined by the curve paramters.
-      * The returned value is the raw big-endian byte serialization of
-        `x-coordinate` (using affine coordinates) of the generated point.
+      * The returned value is the SHA256 of the DER compressed format of the
+	    generated point.
 
   * `HKDF`: a function is defined in [5](#reference-5), evaluated with a
     zero-length `info` field.


### PR DESCRIPTION
You should probably be using this library anyway, so let's use their
ECDH style.

Closes: #49
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>