### PR TITLE
BOLT 7: fix 21-byte limit typo, allow alias to use all characters.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -165,7 +165,7 @@ The creating node MUST set `timestamp` to be greater than any previous
 timestamp.  It MUST set the `ipv6` and `port` fields to all zeroes, or
 a non-zero `port` and `ipv6` set to a valid IPv6 address or an IPv4-Mapped IPv6 Address format as defined in [RFC 4291 section 2.5.5.2](https://tools.ietf.org/html/rfc4291#section-2.5.5.2).  It MUST set `signature` to the signature of
 the double-SHA256 of the entire remaining packet after `signature` using the
-key given by `node-id`.  It MAY set `alias` and `rgb-color` to customize their node's appearance in maps and graphs, where the first byte of `rgb` is the red value, the second byte is the green value and the last byte is the blue value.  It MUST set `alias` to a valid UTF-8 string of up to 21 bytes in length, with all `alias` bytes following equal to zero.
+key given by `node-id`.  It MAY set `alias` and `rgb-color` to customize their node's appearance in maps and graphs, where the first byte of `rgb` is the red value, the second byte is the green value and the last byte is the blue value.  It MUST set `alias` to a valid UTF-8 string, with any `alias` bytes following equal to zero.
 
 The creating node SHOULD set `len` to the minimum length required to
 hold the `features` bits it sets.
@@ -178,8 +178,7 @@ valid signature using `node-id` of the double-SHA256 of the entire
 message following the `signature` field (including unknown fields
 following `alias`), and MUST NOT further process the message.
 
-The receiving node SHOULD ignore `ipv6` if `port` is zero.  It SHOULD
-fail the connection if the final byte of `alias` is not zero.
+The receiving node SHOULD ignore `ipv6` if `port` is zero.
 
 The receiving node SHOULD ignore the message if `node-id` is not
 previously known from a `channel_announcement` message, or if


### PR DESCRIPTION
Fabrice, if you approve, please merge.  Everyone seemed happy with the idea of dropping the nul byte terminator, too.