### PR TITLE
bolt04: Added additional information field to return message

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -390,8 +390,12 @@ The node returning the message builds a return packet consisting of the followin
  - `hmac` (20 bytes): an HMAC authenticating the remainder of the packet, with a key using the above key generation with key type "_um_".
  - `failure code` (4 bytes)
  - `message length` (2 bytes): the length of the message field in bytes
- - `message` (variable): a string representation. The message is
-   padded to 128 bytes with `0x00` bytes.
+ - `message` (variable): a string representation of the message.
+ - `additional length` (2 bytes): the length of any additional protocol level message attached as additional information.
+ - `additional` (variable): a protocol level message, preceeded by the
+   its `type`, as defined by other specifications. For example a route
+   failure MAY include a `channel_update` message to inform the sender
+   that a channel is no longer usable.
 
 The node then generates a new key, using the key type `ammag`.
 This key is then used to generate a 154 byte pseudo-random stream, which is then applied to the packet using `XOR`.


### PR DESCRIPTION
Added an `additional` field to the return message, so that we can
include any protocol level message to inform the sender about the
cause of the failure. This could for example be a `channel_update` if
the channel has become unusable. The message is no longer fixed size,
as hopefully the failure is a rare event, in which case timing
analysis becomes easy anyway.

Closes #53