### PR TITLE
Fix outputs limit and funding output script

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -215,7 +215,7 @@ The recipient MUST fail the channel if `signature` is incorrect, and MUST ignore
 
 #### Rationale
 
-The `output-index` can only be 1 byte, since that's how we'll pack it into the channel-id used throughout the protocol.  The limit of 255 outputs should not be overly burdensome.
+The `output-index` can only be 1 byte, since that's how we'll pack it into the channel-id used throughout the protocol.  The limit of 252 outputs should not be overly burdensome.
 
 ### The `funding_signed` message
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -215,7 +215,7 @@ The recipient MUST fail the channel if `signature` is incorrect, and MUST ignore
 
 #### Rationale
 
-The `output-index` can only be 1 byte, since that's how we'll pack it into the channel-id used throughout the protocol.  The limit of 252 outputs should not be overly burdensome.
+The `output-index` can only be 1 byte, since that's how we'll pack it into the channel-id used throughout the protocol.  The limit of 255 outputs should not be overly burdensome.
 
 ### The `funding_signed` message
 

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -13,7 +13,7 @@ Most transaction outputs used here are P2WSH outputs, the segwit version of P2SH
 ## Funding Transaction Output
 
 * The funding output script is a pay-to-witness-script-hash<sup>[BIP141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#witness-program)</sup> to:
-   * `0 2 <key1> <key2> 2 OP_CHECKMULTISIG`
+   * `2 <key1> <key2> 2 OP_CHECKMULTISIG`
 * Where `key1` is the numerically lesser of the two DER-encoded `funding-pubkey` and `key2` is the greater.
 
 ## Commitment Transaction


### PR DESCRIPTION
- change outputs limit to 252 as more would mean `output-index` > 1 byte
- remove `0` from the funding output script as it is not part of a normal 2-of-2 multisig script

I believe these two corrections are appropriate.

BOLT02 says: "The `output-index` can only be 1 byte.." , this means compact size int up to 0xFC, or 252.

BOLT03 describes the "Funding Transaction Output" as a P2WSH of a 2-of-2 multisig redeemscript of the two commit keys' pubkeys.
This is just a normal 2-of-2 multisig, so `0` isn't really used.