### PR TITLE
BOLT 2: Message retransmission and reconnect semantics.

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -66,7 +66,7 @@ a buffer with 6 bytes of pre-padding.
 
 ### The `init` message
 
-Once authentication is complete, the first message reveals the features supported or required by this node.
+Once authentication is complete, the first message reveals the features supported or required by this node, even if this is a reconnection.
 Odd features are optional, even features are compulsory (_it's OK to be odd_).
 The meaning of these bits will be defined in the future.
 
@@ -81,6 +81,8 @@ The 2 byte `gflen` and `lflen` fields indicate the number of bytes in the immedi
 
 #### Requirements
 
+The sending node MUST send `init` as the first lightning message for any
+connection.
 The sending node SHOULD use the minimum lengths required to represent
 the feature fields.  The sending node MUST set feature bits
 corresponding to features it requires the peer to support, and SHOULD

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -810,12 +810,14 @@ any message), they are independent of requirements here.
 
 A node MUST handle continuing a previous channel on a new encrypted
 transport.  On disconnection, a node MAY forget nodes which have not
-sent or received an `accept_channel` message.
+sent or received an `accept_channel` message, and MAY forget nodes
+which have not sent `funding_locked` after a reasonable timeout.
 
 On disconnection, a node MUST reverse any uncommitted updates sent by
 the other side (ie. all messages beginning with `update_` for which no
-`commitment_signed` has been received).  A node SHOULD retain the `r`
-value from the `update_fulfill_htlc`, however.
+`commitment_signed` has been received).  Note that a node MAY have
+already use the `payment-preimage` value from the `update_fulfill_htlc`,
+so the effects of `update_fulfill_htlc` is not completely reversed.
 
 On reconnection, a node MUST retransmit old messages which may not
 have been received, and MUST NOT retransmit old messages which have


### PR DESCRIPTION
1) Make it clear that `init` needs to be sent every time.
   - This means if you upgrade and no longer support an old connection, it's
     clear, plus it simplifies the question of re-transmission of `init`.
2) Spell out the retransmission requirements for reconnection.
   - We agreed in Milan to simply use retransmit and ignore-dups.
   - This needs actual testing by implementations, but this is my best guess
     on exactly how far back to retransmit.