### PR TITLE
BOLT 2: allow more leniancy with forks during channel establishment.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -263,14 +263,20 @@ The sender MUST wait until the funding transaction has reached
 `minimum-depth` before sending this message.  The sender MUST encode
 the block position of the funding transaction into `channel-id`.  If
 the sender has already received `funding_locked` from the other node,
-it MUST fail the channel if its own `channel-id` does not match the
-received.  The sender MUST set `next-per-commitment-point` to the
+it MAY fail the channel if its own `channel-id` does not match the
+received: otherwise it MUST ignore the `funding_locked` message.
+The sender MAY re-transmit `funding_locked` if the `channel-id` changes.
+
+The sender MUST set `next-per-commitment-point` to the
 per-commitment point to be used for the following commitment
 transaction, derived as specified in
 [BOLT #3](03-transactions.md#per-commitment-secret-requirements).
 
-If the recipient has already sent `funding_locked` it MUST fail the
-channel if `channel-id` does not match the `channel-id` it sent.
+If the recipient has already sent `funding_locked` it MAY fail the
+channel if `channel-id` does not match the `channel-id` it sent,
+otherwise it SHOULD ignore the `funding_locked` message.  If the
+recipient has received previous `funding_locked` message, it MUST
+ignore it in favor of the new `funding_locked`.
 
 The sender MUST set `announcement-node-signature` and `announcement-bitcoin-signature` to the signatures for the
 `channel_announcement` message, or all zeroes if it does not want the
@@ -279,6 +285,18 @@ channel announced.
 The recipient SHOULD fail the channel if the `announcement-node-signature` and `announcement-bitcoin-signature`s are incorrect (and not all zeroes).
 The recipient SHOULD queue the `channel_announcement` message for its
 peers if it has sent and received a non-zero `announcement-node-signature` and `announcement-bitcoin-signature`.
+
+#### Rationale
+
+If the `minimum-depth` is very low (such as 1), it's possible that
+both nodes see different blocks containing the transaction: current
+evidence suggests that this would happen once every three days.  Thus
+we allow implementations to retransmit in this case, and even wait for
+such retransmissions in the case where both `minimum-depth` were too
+low for a canonical answer.
+
+Such waiting is optional, as it is extremely unlikely for
+`minimum-depth` values of 2 or more.
 
 #### Future
 


### PR DESCRIPTION
Christoper points out that two nodes with aggressive minimum-depth settings
may see different blocks and the protocol requires they close the channel
since their funding_locked messages will disagree.

This can also happen when only one side has an aggressive minimum-depth
setting: if it sends funding_locked referring to a block which is orphaned,
it can't update it.

There are three changes here, two optional.
- Allow sending of an updated funding_locked.  This fixes this case where
  one side is on an orphan and uses a v. low minimum-depth.
- Require accepting of an updated funding_locked.
- Allow waiting instead of immediate failure if funding_lock disagrees.
  eg. you might wait another block or two to see if one side reorgs.

Reported-by: Christopher Jämthagen
Closes: #73
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>