### PR TITLE
BOLT 4: make format of failure codes the same as normal messages.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -599,8 +599,8 @@ For a unparsable HTLC:
 2. data:
    * [8:channel-id]
    * [8:id]
-   * [4:failure-code]
    * [32:sha256-of-onion]
+   * [2:failure-code]
 
 #### Requirements
 
@@ -625,7 +625,7 @@ error response if it does not match the onion it sent.
 Otherwise, a receiving node which has an outgoing HTLC canceled by
 `update-fail-malformed-htlc` MUST return an error in the
 `update-fail-htlc` sent to the link which originally sent the HTLC
-using the `failure-code` given and setting the `additional` data to
+using the `failure-code` given and setting the data to
 `sha256-of-onion`.
 
 #### Rationale


### PR DESCRIPTION
This reduces failure codes to 2 bytes, places them into data itself.

Now we can use the same parsing code for them as we use for normal packets.

BOLT 2 is adjusted to match, and order of args changed to restore sha256
alignment to a nice 8 bytes.
