### PR TITLE
Fix packet format extraction tool, add failure codes as packets and add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+script:
+  - (set -e; for i in 0?-*.md; do echo "Extracting $i"; python3 tools/extract-formats.py --message-types --message-fields --check-alignment $i; done)

--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -64,15 +64,17 @@ parser.add_option("--message-fields",
 
 (options, args) = parser.parse_args()
 
-# Example input:
-# 1. type: 17 (`MSG_ERROR`)
+# Example inputs:
+# 1. type: 17 (`error`)
 # 2. data:
 #    * [8:channel-id]
 #    * [4:len]
 #    * [len:data]
+#
+# 1. type: PERM|NODE|3 (`required_node_feature_missing`)
 message = None
 havedata = None
-typeline = re.compile('1\. type: (?P<value>[0-9]+) \(`(?P<name>[-A-Za-z_]+)`\)')
+typeline = re.compile('1\. type: (?P<value>[-0-9A-Za-z_|]+) \(`(?P<name>[-A-Za-z_]+)`\)')
 dataline = re.compile('\s+\* \[(?P<size>[-a-z0-9*+]+):(?P<name>[-a-z0-9]+)\]')
 
 for i,line in enumerate(fileinput.input(args)):
@@ -89,7 +91,7 @@ for i,line in enumerate(fileinput.input(args)):
         havedata = None
     elif message is not None and havedata is None:
         if line != '2. data:':
-            raise ValueError('{}:Expected 2. data:'.format(linenum))
+            message = None
         havedata = True
         dataoff = 0
         off_extraterms = ""

--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -16,27 +16,27 @@ def guess_alignment(message,name,sizestr):
     # - node_announcement.ipv6 has size 16, but alignment 4 (to align IPv4 addr).
     # - node_announcement.alias is a string, so alignment 1
     # - signatures have no alignment requirement.
-    if match.group('name').startswith('pad'):
+    if name.startswith('pad'):
         return 1
 
-    if match.group('name') == 'channel-id':
+    if name == 'channel-id':
         return 4
 
-    if message == 'node_announcement' and match.group('name') == 'ipv6':
+    if message == 'node_announcement' and name == 'ipv6':
         return 4
 
-    if message == 'node_announcement' and match.group('name') == 'alias':
+    if message == 'node_announcement' and name == 'alias':
         return 1
 
-    if 'signature' in match.group('name'):
+    if 'signature' in name:
        return 1
     
     # Size can be variable.
     try:
-        size = int(match.group('size'))
+        size = int(sizestr)
     except ValueError:
         # If it contains a "*xxx" factor, that's our per-unit size.
-        s = re.search('\*([0-9]*)$', match.group('size'))
+        s = re.search('\*([0-9]*)$', sizestr)
         if s is None:
             size = 1
         else:


### PR DESCRIPTION
The extraction tool was broken by the recent failure codes patch, since the failure codes description was using the same format that the tool recognized as packet types. This seems to be desirable since it allows us to reuse that tool to create parsers for the failure payloads as well. So I went ahead and fixed the tool to allow packets with no payloads and match masked types as well.

I also added travis-ci (must still be enabled by a repo owner) so that the extraction tool is run against new commits and we get feedback on breakages. Maybe we can expand this to also enforce some spec styles in the future?