### PR TITLE
BOLT 3: Fix so commitment transactions are spendable

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -51,7 +51,7 @@ Most transaction outputs used here are P2WSH outputs, the segwit version of P2SH
 
 ## Commitment Transaction
 * version: 2
-* locktime: upper 8 bits are zero, lower 24 bits are the lower 24 bits of the obscured commitment transaction number.
+* locktime: upper 8 bits are 0x20, lower 24 bits are the lower 24 bits of the obscured commitment transaction number.
 * txin count: 1
    * `txin[0]` outpoint: `txid` and `output_index` from `funding_created` message
    * `txin[0]` sequence: upper 8 bits are 0x80, lower 24 bits are upper 24 bits of the obscured commitment transaction number.


### PR DESCRIPTION
The lower 24 bits of the locktime represents the lower 24 bits of the 
obscured commitment transaction number. If the high byte of locktime 
is always zero, then the locktime value can only assume a maximum 
value of 16,777,215 which is below 500,000,000, meaning the locktime 
will always be compared to block height and not MTP, if enabled.

The most significant byte of the locktime in a commitment transaction
must be set to 0x20. This is to make sure that the locktime value
is always higher than 500,000,000, making it interpreted as a Unix
epoch timestamp, and not a block height. It also makes sure that the
locktime is below the current time, allowing the commitment transaction
to be included in a block

Since the sequence field in the input of the commitment transaction is
used for the other half of the obscured commitment transaction number,
it will never assume the maxInt value (0xFFFFFFFF) which would disable
locktime checking.

This was verified to work in lnd via https://github.com/lightningnetwork/lnd/pull/93/commits/be9ba26faa8201de54bee12404e6ca8bd1dc89c8