### PR TITLE
BOLT 3: use P2WPKH instead of P2PKH.

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -103,7 +103,7 @@ If a revoked commitment transaction is published, the other party can spend this
 
 #### To-Remote Output
 
-This output sends funds to the other peer, thus is a simple P2PKH to `remotekey`.
+This output sends funds to the other peer, thus is a simple P2WPKH to `remotekey`.
 
 #### Offered HTLC Outputs
 


### PR DESCRIPTION
Not only is it shorter and cheaper, but the rest of the document (including
test vectors and weight calculation) assumed it already.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>