### PR TITLE
BOLT 4: Use 4 bytes for outgoing_cltv_value

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -142,7 +142,7 @@ the values as specified within the per-hop-payload.
 The format of the per-hop-payload for a version 0 packet is as follows: 
 ```
 +----------------+--------------------------+-------------------------------+--------------------------------------------+
-| realm (1 byte) | amt_to_forward (8 bytes) | outgoing_cltv_value (2 bytes) | unused_with_v0_version_on_header (9 bytes) |
+| realm (1 byte) | amt_to_forward (8 bytes) | outgoing_cltv_value (4 bytes) | unused_with_v0_version_on_header (7 bytes) |
 +----------------+--------------------------+-------------------------------+--------------------------------------------+
 ```
 


### PR DESCRIPTION
The cltv value in the `per-hop-payload` packet is an absolute value, not a delta, therefore it needs to be encoded on 4 bytes just like `update_add_htlc`.`cltv-expiry`.

To keep the packet length at 20 bytes I removed 2 bytes from the following unused field.