### PR TITLE
BOLT 7: Added flag for optional initial routing sync dump

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -294,6 +294,14 @@ channels associated with it.  Otherwise the receiving node SHOULD
 queue the message for rebroadcasting, but MAY choose not to for
 messages longer than the minimum expected length.
 
+## Initial Sync
+
+Upon establishing a connection, the two endpoints negotiate whether to perform an initial sync by setting the `initial_routing_sync` flags in the `init` message.
+The endpoint SHOULD set the `initial_routing_sync` flag if it requires a full copy of the other endpoint's routing state.
+Upon receiving an `init` message with the `initial_routing_sync` flag set the node sends `channel_announcement`s, `channel_update`s and `node_announcement`s for all known channels and nodes as if they were just received. 
+
+If the `initial_routing_sync` flag is not set, or initial sync was completed, then the node resumes normal operation, see the _Rebroadcasting_ section for details.
+
 ## Rebroadcasting
 
 Nodes receiving a new `channel_announcement` or a `channel_update` or

--- a/09-features.md
+++ b/09-features.md
@@ -15,5 +15,6 @@ Flags begin at bit 0 (ie. 0x1), and odd-numbered flags (eg. 0x2) are optional.
 | Bits | Name             |Description                                     | Link                                                                |
 |------|------------------|------------------------------------------------|---------------------------------------------------------------------|
 | 0/1  | `channel_public` | The sending node wishes to announce the channel | [BOLT #7](07-routing-gossip.md#the-announcement_signatures-message) |
+| 2/3  | `initial_routing_sync` | The sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 
 ## Assigned `globalfeatures` flags


### PR DESCRIPTION
Opening a lot of connections results in getting this information a
whole lot of times, so let's add an opt-in flag for the initial dump.

This will cause a conflict with #102, I'll rebase once that is merged.