### PR TITLE
BOLT 9: Make it clear that 'channel_public' apply to all channels

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -23,12 +23,12 @@ It contains the necessary signatures by the sender to construct the `channel_ann
     * [64:node-signature]
     * [64:bitcoin-signature]
 
-The willingness of the endpoints to announce the channel is signaled during the connection setup by setting a `channel_public` bit in the `localfeatures` field.
+The willingness of the endpoints to announce the channel is signaled during the connection setup by setting a `channels_public` bit in the `localfeatures` field.
 Should both endpoints have signaled that they'd like to publish the channel then the `announcement_signatures` message MUST directly sent following the `funding_locked` message that established the corresponding channel.
 The `announcement_signatures` message is created by constructing a `channel_announcement` message corresponding to the newly established channel, and sign it with the secrets matching their `node-id` and `bitcoin-key`, and send them using an `announcement_signatures`.
 The recipient MAY fail the channel if the `node-signature` or `bitcoin-signature` is incorrect.
 The recipient SHOULD queue the `channel_announcement` message for its peers if it has sent and received a valid `announcement_signatures` message.
-If either endpoints does not signal `channel_public` then `announcement_signatures` MUST NOT be sent.
+If either endpoints does not signal `channels_public` then `announcement_signatures` MUST NOT be sent.
 
 ## The `channel_announcement` message
 

--- a/09-features.md
+++ b/09-features.md
@@ -14,7 +14,7 @@ Flags begin at bit 0 (ie. 0x1), and odd-numbered flags (eg. 0x2) are optional.
 
 | Bits | Name             |Description                                     | Link                                                                |
 |------|------------------|------------------------------------------------|---------------------------------------------------------------------|
-| 0/1  | `channel_public` | The sending node wishes to announce the channel | [BOLT #7](07-routing-gossip.md#the-announcement_signatures-message) |
+| 0/1  | `channels_public` | The sending node wishes to announce channels | [BOLT #7](07-routing-gossip.md#the-announcement_signatures-message) |
 | 2/3  | `initial_routing_sync` | The sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 
 ## Assigned `globalfeatures` flags


### PR DESCRIPTION
This follows #109 and Christian's [comment ](https://github.com/lightningnetwork/lightning-rfc/pull/97#issuecomment-277683797) in #97.

I have also renamed `channel_public` to `channels_public`.