### PR TITLE
BOLT 9: Added a `retransmit-channelid` feature bit

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -16,5 +16,6 @@ Flags begin at bit 0 (ie. 0x1), and odd-numbered flags (eg. 0x2) are optional.
 |------|------------------|------------------------------------------------|---------------------------------------------------------------------|
 | 0/1  | `channel_public` | The sending node wishes to announce the channel | [BOLT #7](07-routing-gossip.md#the-announcement_signatures-message) |
 | 2/3  | `initial_routing_sync` | The sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
+| 4/5  | `retransmit_channelid` | The sending node will re-transmit `funding_locked` messages until peers agree on the same `channel-id` instead of failing right away.| [BOLT #2](02-peer-protocol.md#the-funding_locked-message) |
 
 ## Assigned `globalfeatures` flags


### PR DESCRIPTION
This would allow a node to announce what it will do when there is a `channel-id` mismatch in the `funding-locked` step. I hesitated with an opposite `fail-on-channelid-mismatch` feature.

I am not too sure about this, but I think it might be better to be explicit?

Note that in the Rationale, BOLT 2 says that "we require that they send updates to avoid relying on timeouts" but there is nothing in the Requirements section about that 