### PR TITLE
BOLT 2: revoke_and_ack is not acked by update messages

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -922,7 +922,7 @@ lists the acknowledgement conditions for each message:
 * `funding_locked`: acknowledged by `update_` messages, `commitment_signed`, `revoke_and_ack` or `shutdown` messages.
 * `update_` messages: acknowledged by `revoke_and_ack`.
 * `commitment_signed`: acknowledged by `revoke_and_ack`.
-* `revoke_and_ack`: acknowledged by `shutdown`, `update_` messages, or `commitment_signed`
+* `revoke_and_ack`: acknowledged by `shutdown` or `commitment_signed`
 * `shutdown`: acknowledged by `closing_signed` or `revoke_and_ack`.
 
 The last `closing_signed` (if any) must always be retransmitted, as there


### PR DESCRIPTION
I think `revoke_and_ack` is only acknowledged by `commitment_signed` and `shutdown` because in the following scenario B can send update messages while waiting for revocation):
```
A                                B
|              add               |
|<-------------------------------|
|              sig               |
|<-------------------------------|
| rev                        add |
|---------------  ---------------|
|               \/               |
|               /\               |
|<--------------  -------------->|
|              sig               |
|<-------------------------------|
|              rev               |
|------------------------------->|
```

In our current implementation, `revoke_and_ack` is not even acknowledged by `shutdown` but it might be a little bit far fetched? For example this is legal in eclair:
```
A                                B
|              add               |
|<-------------------------------|
|              sig               |
|<-------------------------------|
| rev                   shutdown |
|---------------  ---------------|
|               \/               |
|               /\               |
|<--------------  -------------->|
|              shutdown          |
|------------------------------->|
```