### PR TITLE
BOLT 2: revoke_and_ack is acknowledged by closing_signed

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -873,7 +873,7 @@ lists the acknowledgement conditions for each message:
 * `funding_locked`: acknowledged by `update_` messages, `commitment_signed`, `revoke_and_ack` or `shutdown` messages.
 * `update_` messages: acknowledged by `revoke_and_ack`.
 * `commitment_signed`: acknowledged by `revoke_and_ack`.
-* `revoke_and_ack`: acknowledged by `shutdown` or `commitment_signed`
+* `revoke_and_ack`: acknowledged by `shutdown`, `commitment_signed` or `closing_signed`
 * `shutdown`: acknowledged by `closing_signed` or `revoke_and_ack`.
 
 The last `closing_signed` (if any) must always be retransmitted, as there


### PR DESCRIPTION
In the following scenario B's last `revoke_and_ack` is acknowledged by A's `closing_signed`

```
A                                B
|                                |
|              add               |
|------------------------------->|
|              sig               |
|------------------------------->|
|              rev               |
|<-------------------------------|
|                                |
|              sig               |
|<-------------------------------|
|              rev               |
|------------------------------->|
|                                |
|            shutdown            |
|------------------------------->|
|            shutdown            |
|<-------------------------------|
|                                |
|            fulfill             |
|<------------------------------>|
|              sig               |
|<-------------------------------|
|              rev               |
|------------------------------->|
|                                |
|              sig               |
|------------------------------->|
|              rev               |
|<-------------------------------|
|                                |
| closing_signed  closing_signed |
|---------------  ---------------|
|               \/               |
|               /\               |
|<--------------  -------------->|
```