### PR TITLE
BOLT 4: allow more overpaying.

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -592,8 +592,10 @@ If the payment hash is unknown, the final node MUST fail the HTLC:
 1. type: PERM|15 (`unknown_payment_hash`)
 
 If the amount paid is less than the amount expected, the final node
-MUST fail the HTLC.  If the amount paid is more than the amount
-expected, the final node SHOULD fail the HTLC:
+MUST fail the HTLC.  If the amount paid is more than twice the amount
+expected, the final node SHOULD fail the HTLC.  This allows the sender
+to reduce information leakage by altering the amount, without allowing
+accidental gross overpayment:
 
 1. type: PERM|16 (`incorrect_payment_amount`)
 


### PR DESCRIPTION
The idea of the "SHOULD fail if amount is too much" was courtesy against
overpaying, but that's a bad idea of you value privacy and some vendor has
well-known prices.  Allow a factor of two, at least.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>