### PR TITLE
BOLT 4: error if the final outgoing_ctlv_value is unexpected.

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -174,9 +174,13 @@ Field Description:
      Inclusion of this field allows a node to both authenticate the information
      specified by the original sender and the paramaters of the HTLC forwarded,
 	 and ensure the original sender is using the current `cltv-expiry-delta` value.
+     If there is no next hop, `cltv-expiry-delta` is zero.
      If the values don't correspond, then the HTLC should be failed+rejected as
      this indicates the incoming node has tampered with the intended HTLC
      values, or the origin has an obsolete `cltv-expiry-delta` value.
+     The node MUST be consistent in responding to an unexpected
+     `outgoing_cltv_value` whether it is the final hop or not, to avoid
+     leaking that information.
 
 
 Nodes forwarding HTLC's MUST construct the outgoing HTLC as specified within
@@ -600,6 +604,13 @@ expected, the final node SHOULD fail the HTLC:
 If the `cltv-expiry` is too low, the final node MUST fail the HTLC:
 
 1. type: 17 (`final_expiry_too_soon`)
+
+If the `outgoing_cltv_value` does not match the `ctlv-expiry` of the
+HTLC at the final hop:
+
+1. type: 18 (`final_incorrect_cltv_expiry`)
+2. data:
+   * [4:cltv-expiry]
 
 ### Receiving Failure Codes
 

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -164,7 +164,8 @@ Field Description:
         incoming_htlc_amt - fee >= amt_to_forward
 
      Where `fee` is calculated according to the receving node's advertised fee
-     schema as described in [BOLT 7](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#htlc-fees).
+     schema as described in [BOLT 7](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#htlc-fees), or 0 if this node is the
+	 final hop.
 
    * `outgoing_cltv_value` - The CLTV value that the _outgoing_ HTLC carrying
      the packet should have. 
@@ -611,6 +612,13 @@ HTLC at the final hop:
 1. type: 18 (`final_incorrect_cltv_expiry`)
 2. data:
    * [4:cltv-expiry]
+
+If the `amt_to_forward` does not match the `incoming_htlc_amt` of
+the HTLC at the final hop:
+
+1. type: 19 (`final_incorrect_htlc_amount`)
+2. data:
+   * [4:incoming-htlc-amt]
 
 ### Receiving Failure Codes
 


### PR DESCRIPTION
Not doing this check means an inconsistency in behaviour, which could
theoretically allow a hop to probe: if the next hop is the last, it might
not care, but if it's not it will return an error.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>