### PR TITLE
bolt07: Add flag to disable channels temporarily.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -276,11 +276,6 @@ it wants to change fees.
     * [4:fee-base-msat]
     * [4:fee-proportional-millionths]
 
-### Requirements
-
-The creating node MUST set `signature` to the signature of the
-double-SHA256 of the entire remaining packet after `signature` using its own `node-id`.
-
 The flags bitfield is used to indicate the direction of the channel this update concerns, i.e., it identifies the node that this update originated from, and signal various options concerning the channel.
 The following table specifies the meaning of the individual bits:
 
@@ -288,6 +283,11 @@ The following table specifies the meaning of the individual bits:
 | ------------- | ----------- | -------------------------------- |
 | 0             | `direction` | Direction this update refers to. |
 | 1             | `disable`   | Disable the channel.             |
+
+### Requirements
+
+The creating node MUST set `signature` to the signature of the
+double-SHA256 of the entire remaining packet after `signature` using its own `node-id`.
 
 The creating node MUST set `short-channel-id` to match those in the already-sent `channel_announcement` message, and MUST set the least-significant bit of `flags` to 0 if the creating node is `node-id-1` in that message, otherwise 1.
 Bits which are not assigned a meaning must be set to 0.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -281,8 +281,19 @@ it wants to change fees.
 The creating node MUST set `signature` to the signature of the
 double-SHA256 of the entire remaining packet after `signature` using its own `node-id`.
 
-The creating node MUST set `short-channel-id` to
-match those in the already-sent `channel_announcement` message, and MUST set the least-significant bit of `flags` to 0 if the creating node is `node-id-1` in that message, otherwise 1.  It MUST set other bits of `flags` to zero.
+The flags bitfield is used to indicate the direction of the channel this update concerns, i.e., it identifies the node that this update originated from, and signal various options concerning the channel.
+The following table specifies the meaning of the individual bits:
+
+| Bit Position  | Name        | Meaning                          |
+| ------------- | ----------- | -------------------------------- |
+| 0             | `direction` | Direction this update refers to. |
+| 1             | `disable`   | Disable the channel.             |
+
+The creating node MUST set `short-channel-id` to match those in the already-sent `channel_announcement` message, and MUST set the least-significant bit of `flags` to 0 if the creating node is `node-id-1` in that message, otherwise 1.
+Bits which are not assigned a meaning must be set to 0.
+
+A node MAY create and send a `channel_update` with the `disable` bit set to signal the temporary unavailability of a channel, e.g., due to loss of connectivity, or the permanent unavailability, e.g., ahead of an on-chain settlement.
+A subsequent `channel_update` with the `disable` bit unset MAY re-enable the channel.
 
 The creating node MUST set `timestamp` to greater than zero, and MUST set it to greater than any previously-sent `channel_update` for this channel.
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -289,7 +289,7 @@ The following table specifies the meaning of the individual bits:
 The creating node MUST set `signature` to the signature of the
 double-SHA256 of the entire remaining packet after `signature` using its own `node-id`.
 
-The creating node MUST set `short-channel-id` to match those in the already-sent `channel_announcement` message, and MUST set the least-significant bit of `flags` to 0 if the creating node is `node-id-1` in that message, otherwise 1.
+The creating node MUST set `short-channel-id` to match those in the already-sent `channel_announcement` message, and MUST set the `direction` bit of `flags` to 0 if the creating node is `node-id-1` in that message, otherwise 1.
 Bits which are not assigned a meaning must be set to 0.
 
 A node MAY create and send a `channel_update` with the `disable` bit set to signal the temporary unavailability of a channel, e.g., due to loss of connectivity, or the permanent unavailability, e.g., ahead of an on-chain settlement.


### PR DESCRIPTION
This is useful to signal either permanent or temporary channel unavailability. Temporary unavailability may include anything from a connection loss for mobile nodes, or prolonged lack of capacity, though I'd like to discourage the latter. In the case of permanent unavailability this can frontrun the actual closure and tell nodes not to use this channel (-direction) even before they see the on-chain close.

It's more of a heads up, and on-chain settlements should be used for permanent removal.