### PR TITLE
bolt10: Initial draft of the subdomain structure.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -291,3 +291,16 @@ UTC
 inline
 fundee's
 BOLTs
+DNS
+subdomain
+subdomains
+wildcard
+tuple
+tuples
+resolvers
+hostnames
+prepending
+A
+AAAA
+SRV
+TTL

--- a/10-dns-bootstrap.md
+++ b/10-dns-bootstrap.md
@@ -62,7 +62,7 @@ In accordance with the Bitcoin DNS Seed policy<sup>[4](#ref-4)</sup>, replies to
 Querying for `AAAA` records:
 
 	$ dig lseed.bitcoinstats.com AAAA
-	lseed.bitcoinstats.com. 60      IN      AAAA    2a02:aa16:1105:4a80:aead:aad2:37ce:9ca
+	lseed.bitcoinstats.com. 60      IN      AAAA    2a02:aa16:1105:4a80:1234:1234:37c1:9c9
 
 Querying for `SRV` records:
 

--- a/10-dns-bootstrap.md
+++ b/10-dns-bootstrap.md
@@ -1,0 +1,57 @@
+# BOLT #10: DNS Bootstrap and Assisted Node Location
+
+This specification describes a node discovery mechanism based on the Domain Name System.
+Its purpose is twofold:
+
+ - Bootstrap: the initial node discovery for nodes that have no known contacts in the network
+ - Assisted Node Location: supporting nodes to discover the current network address previously known peers
+
+A domain name server implementing this specification is called a _DNS Seed_, and answers incoming DNS queries of type `A`, `AAAA` or `SRV` as specified in RFCs 1035<sub>[1](#ref-1)</sup>, 3596<sub>[2](#ref-2)</sup> and 2782<sub>[3](#ref-3)</sup> respectively.
+The DNS server is authoritative for a subdomain, called a _seed root domain_, and clients may query either the seed root domain or subdomains thereunder.
+
+## Subdomain Structure
+
+A client MAY query the seed root domain for either `A`, `AAAA` or `SRV` records.
+Upon receiving `A` and `AAAA` queries the DNS seed MUST return a random subset of up to 25 IPv4 or IPv6 addresses of nodes that are listening for incoming connections on the default port 9735 as defined in [BOLT 01](01-messaging.md).
+In accordance with the Bitcoin DNS Seed policy<sub>[4](#ref-4)</sup> the DNS seed operator MAY NOT bias the result in any form, apart from filtering non-functioning or malicious nodes from the result.
+The domain name associated with the addresses returned to `A` and `AAAA` queries MUST match the domain name in the query in order not to be filtered by intermediate resolvers.
+
+Upon receiving `SRV` queries the DNS seed MUST return a random subset of up to 5 (_virtual hostnames_, port)-tuples.
+A virtual hostname is a subdomain of the seed root domain that uniquely identifies a node in the network.
+It is constructed by splitting the hex encoded `node_id` of the node into two parts, each no longer than 64 characters, dropping any leading `0` characters, separating them with a single period (`.`), and prepending it as a subdomain to the seed root domain.
+The DNS seed MAY additionally return the corresponding `A` and `AAAA` indicating the IP address for the `SRV` entries in the Extra section of the reply.
+Due to the large size of the resulting reply it may happen that the reply is dropped by intermediate resolvers, hence the DNS seed MAY omit these additional records upon detecting a repeated query.
+The DNS seed MUST also allow the `_nodes._tcp.` subdomain for `SRV` queries.
+This is the standard compliant version as specified in RFC 2782<sub>[3](#ref-3).
+
+A client MAY ask directly for the `A` or `AAAA` record for a specific node by querying for the virtual hostname.
+This may either be due to a previous `SRV` reply that omitted the extra section, or because the client is attempting to locate a specific node it was connected to before.
+Upon receiving an `SRV` query for a virtual hostname, the DNS seed reconstructs the `node id` by removing the separating period and looking the IP address up in its local network view.
+The DNS seed MUST return all known IP addresses for the queried `node id`.
+In case of an IP class mismatch, e.g., the client asked for IPv4 addresses with an `A` query, but the result is an IPv6 `AAAA` record, then the record MUST be returned in the extra section.
+This MAY result in an empty reply, with the actual result in the extra section, and clients MUST handle it accordingly.
+The domain name returned in an `A` or `AAAA` reply MUST match the virtual hostname from the query in order not to be dropped by intermediate resolvers.
+
+
+## Examples
+
+Querying for `AAAA` records:
+
+	lseed.bitcoinstats.com. 60      IN      AAAA    2a02:aa16:1105:4a80:aead:aad2:37ce:9ca
+
+Querying for `SRV` records:
+
+	lseed.bitcoinstats.com. 60      IN      SRV     10 10 23202 3e2a4210722570eaa18200c3a5b5fc6f40ebd7d698724a3bf2cd5dd5fea4d93.bb.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 60      IN      SRV     10 10 23201 314e8aff96ec581394af4e7600c7f5b3646fce8e55d56f9e82adbeeb2d9d4f6.25.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 60      IN      SRV     10 10 23201 203b525e1096f4b06f60d93bc78da0d062aef90fb398db786285ac8911b9f8b.40.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 60      IN      SRV     10 10 6334 2233e25e33d1e652beaf9d32f64a8383c6b63bc82fcdeb8a3588092e490ef55.7e.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 60      IN      SRV     10 10 6331 26fad0132cdde76e2e5cd77b822ef21392b547566814ed21028d88281540ee6.36.lseed.bitcoinstats.com.
+
+Querying for the `A` for the first virtual hostname from the previous example:
+
+	3e2a4210722570eaa18200c3a5b5fc6f40ebd7d698724a3bf2cd5dd5fea4d93.bb.lseed.bitcoinstats.com. 60 IN A 45.32.248.251
+
+## References
+- <a id="ref-1">[RFC 1035 - Domain Names](https://www.ietf.org/rfc/rfc1035.txt)</a>
+- <a id="ref-2">[RFC 3596 - DNS Extensions to Support IP Version 6](https://tools.ietf.org/html/rfc3596)</a>
+- <a id="ref-3">[RFC 2782 - A DNS RR for specifying the location of services (DNS SRV)](https://www.ietf.org/rfc/rfc2782.txt)</a>

--- a/10-dns-bootstrap.md
+++ b/10-dns-bootstrap.md
@@ -82,3 +82,4 @@ Querying for the `A` for the first virtual hostname from the previous example:
 - <a id="ref-1">[RFC 1035 - Domain Names](https://www.ietf.org/rfc/rfc1035.txt)</a>
 - <a id="ref-2">[RFC 3596 - DNS Extensions to Support IP Version 6](https://tools.ietf.org/html/rfc3596)</a>
 - <a id="ref-3">[RFC 2782 - A DNS RR for specifying the location of services (DNS SRV)](https://www.ietf.org/rfc/rfc2782.txt)</a>
+- <a id="ref-4">[Expectations for DNS Seed operators](https://github.com/bitcoin/bitcoin/blob/master/doc/dnsseed-policy.md)</a>

--- a/10-dns-bootstrap.md
+++ b/10-dns-bootstrap.md
@@ -7,54 +7,76 @@ Its purpose is twofold:
  - Assisted Node Location: supporting nodes to discover the current network address previously known peers
 
 A domain name server implementing this specification is called a _DNS Seed_, and answers incoming DNS queries of type `A`, `AAAA` or `SRV` as specified in RFCs 1035<sup>[1](#ref-1)</sup>, 3596<sup>[2](#ref-2)</sup> and 2782<sup>[3](#ref-3)</sup> respectively.
-The DNS server is authoritative for a subdomain, called a _seed root domain_, and clients may query either the seed root domain or subdomains thereunder.
+The DNS server is authoritative for a subdomain, called a _seed root domain_, and clients may query it for subdomains.
 
-## Subdomain Structure
+The subdomains consist of a number of dot-separated _conditions_ that further narrow the desired results.
 
-A client MAY query the seed root domain for either `A`, `AAAA` or `SRV` records.
-Upon receiving `A` and `AAAA` queries the DNS seed MUST return a random subset of up to 25 IPv4 or IPv6 addresses of nodes that are listening for incoming connections on the default port 9735 as defined in [BOLT 01](01-messaging.md).
-In accordance with the Bitcoin DNS Seed policy<sup>[4](#ref-4)</sup> the DNS seed operator MAY NOT bias the result in any form, apart from filtering non-functioning or malicious nodes from the result.
-The domain name associated with the addresses returned to `A` and `AAAA` queries MUST match the domain name in the query in order not to be filtered by intermediate resolvers.
+## DNS Seed Queries
 
-Upon receiving `SRV` queries the DNS seed MUST return a random subset of up to 5 (_virtual hostnames_, port)-tuples.
+A client MAY issue queries using either the `A`, `AAAA` or `SRV` query types, specifying conditions for the desired results the seed should return.
+
+### Query Semantics
+
+The conditions are key-value pairs with a single letter key and the remainder as the value.
+The following key-value pairs MUST be supported by a DNS seed:
+
+ - `r`: realm byte, used to specify what realm the returned nodes must support (default value: 0, Bitcoin)
+ - `a`: address types, used to specify what address types should be returned for `SRV` queries. This is a bitfield using the types from [BOLT 7](07-routing-gossip.md) as bit index. This condition MAY only be used for `SRV` queries. (default value: 6, i.e., `2 || 4`, IPv4 and IPv6)
+ - `l`: `node_id`, the bech32 encoded `node_id` of a specific node, used to ask for a single node instead of a random selection. (default: null)
+ - `n`: textual representation of the number of desired reply records (default: 25)
+
+Results returned by the DNS seed SHOULD match all conditions.
+If the DNS seed does not implement filtering by a given condition it MAY ignore the condition altogether, i.e., the seed filtering is best effort only.
+Clients MUST NOT rely on any given condition being met by the results.
+
+We distinguish between _wildcard_ queries and _node_ queries, depending on whether the `l`-key is set or not.
+Upon receiving a wildcard query the DNS seed MUST select a random subset of up to `n` IPv4 or IPv6 addresses of nodes that are listening for incoming connections.
+For `A` and `AAAA` queries only nodes listening on the default port 9735 as defined in [BOLT 01](01-messaging.md) MUST be returned.
+Since `SRV` records return a _(hostname,port)_-tuple, nodes that are listening on non-default ports MAY be returned.
+
+Upon receiving a node query, the seed MUST select the record matching the `node_id` if any, and return all addresses associated with that node.
+
+### Reply Construction
+
+The results are serialized in a reply with a query type matching the client's query type, i.e., `A` queries result in `A` replies, `AAAA` queries result in `AAAA` replies and `SRV` queries result in `SRV` replies, but may be augmented with additional records, e.g., to add `A` or `AAAA` records matching the returned `SRV` records.
+
+For `A` and `AAAA` queries the reply contains the domain name and the IP address of the results.
+The domain name MUST match the domain in the query in order not to be filtered by intermediate resolvers.
+
+For `SRV` queries the reply consists of (_virtual hostnames_, port)-tuples
 A virtual hostname is a subdomain of the seed root domain that uniquely identifies a node in the network.
-It is constructed by splitting the hex encoded `node_id` of the node into two parts, each no longer than 64 characters, dropping any leading `0` characters, separating them with a single period (`.`), and prepending it as a subdomain to the seed root domain.
+It is constructed by prepending the `node_id` condition to the seed root domain.
 The DNS seed MAY additionally return the corresponding `A` and `AAAA` indicating the IP address for the `SRV` entries in the Extra section of the reply.
 Due to the large size of the resulting reply it may happen that the reply is dropped by intermediate resolvers, hence the DNS seed MAY omit these additional records upon detecting a repeated query.
-The DNS seed MUST also allow the `_nodes._tcp.` subdomain for `SRV` queries.
-This is the standard compliant version as specified in RFC 2782<sup>[3](#ref-3)</sup>.
 
-A client MAY ask directly for the `A` or `AAAA` record for a specific node by querying for the virtual hostname.
-This may either be due to a previous `SRV` reply that omitted the extra section, or because the client is attempting to locate a specific node it was connected to before.
-Upon receiving an `SRV` query for a virtual hostname, the DNS seed reconstructs the `node id` by removing the separating period and looking the IP address up in its local network view.
-The DNS seed MUST return all known IP addresses for the queried `node id`.
-In case of an IP class mismatch, e.g., the client asked for IPv4 addresses with an `A` query, but the result is an IPv6 `AAAA` record, then the record MUST be returned in the extra section.
-This MAY result in an empty reply, with the actual result in the extra section, and clients MUST handle it accordingly.
-The domain name returned in an `A` or `AAAA` reply MUST match the virtual hostname from the query in order not to be dropped by intermediate resolvers.
+Should no entries match all the conditions then an empty reply MUST be returned.
 
 ## Policies
 
 The DNS seed MUST NOT return replies with a TTL lower than 60 seconds.
 The DNS seed MAY filter nodes from its local views for various reasons, including faulty nodes, flaky nodes, or spam prevention.
-Replies to random queries, i.e., queries to the seed root domain and the `_nodes._tcp.` alias for `SRV` queries, MUST be random samples from the set of all known good nodes and MUST NOT be biased.
+In accordance with the Bitcoin DNS Seed policy<sup>[4](#ref-4)</sup>, replies to random queries, i.e., queries to the seed root domain and the `_nodes._tcp.` alias for `SRV` queries, MUST be random samples from the set of all known good nodes and MUST NOT be biased.
 
 ## Examples
 
 Querying for `AAAA` records:
 
+	$ dig lseed.bitcoinstats.com AAAA
 	lseed.bitcoinstats.com. 60      IN      AAAA    2a02:aa16:1105:4a80:aead:aad2:37ce:9ca
 
 Querying for `SRV` records:
 
-	lseed.bitcoinstats.com. 60      IN      SRV     10 10 23202 3e2a4210722570eaa18200c3a5b5fc6f40ebd7d698724a3bf2cd5dd5fea4d93.bb.lseed.bitcoinstats.com.
-	lseed.bitcoinstats.com. 60      IN      SRV     10 10 23201 314e8aff96ec581394af4e7600c7f5b3646fce8e55d56f9e82adbeeb2d9d4f6.25.lseed.bitcoinstats.com.
-	lseed.bitcoinstats.com. 60      IN      SRV     10 10 23201 203b525e1096f4b06f60d93bc78da0d062aef90fb398db786285ac8911b9f8b.40.lseed.bitcoinstats.com.
-	lseed.bitcoinstats.com. 60      IN      SRV     10 10 6334 2233e25e33d1e652beaf9d32f64a8383c6b63bc82fcdeb8a3588092e490ef55.7e.lseed.bitcoinstats.com.
-	lseed.bitcoinstats.com. 60      IN      SRV     10 10 6331 26fad0132cdde76e2e5cd77b822ef21392b547566814ed21028d88281540ee6.36.lseed.bitcoinstats.com.
+	$ dig lseed.bitcoinstats.com SRV
+	lseed.bitcoinstats.com. 59   IN      SRV     10 10 6331 ln1qwktpe6jxltmpphyl578eax6fcjc2m807qalr76a5gfmx7k9qqfjwy4mctz.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 59   IN      SRV     10 10 9735 ln1qv2w3tledmzczw227nnkqrrltvmydl8gu4w4d70g9td7avke6nmz2tdefqp.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 59   IN      SRV     10 10 9735 ln1qtynyymv99pqf0r9cuexvvqtxrlgejuecf8myfsa96vcpflgll5cqmr2xsu.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 59   IN      SRV     10 10 4280 ln1qdfvlysfpyh96apy3w3qdwlu8jjkdhnuxa689ka540tnde6gnx86cf7ga2d.lseed.bitcoinstats.com.
+	lseed.bitcoinstats.com. 59   IN      SRV     10 10 4281 ln1qwf789tlcpe4n34649xrqllxt97whsvfk5pm07ggqms3vrjwdj3cu6332zs.lseed.bitcoinstats.com.
 
 Querying for the `A` for the first virtual hostname from the previous example:
 
-	3e2a4210722570eaa18200c3a5b5fc6f40ebd7d698724a3bf2cd5dd5fea4d93.bb.lseed.bitcoinstats.com. 60 IN A 45.32.248.251
+	$dig ln1qwktpe6jxltmpphyl578eax6fcjc2m807qalr76a5gfmx7k9qqfjwy4mctz.lseed.bitcoinstats.com A
+	ln1qwktpe6jxltmpphyl578eax6fcjc2m807qalr76a5gfmx7k9qqfjwy4mctz.lseed.bitcoinstats.com. 60 IN A 139.59.143.87
 
 ## References
 - <a id="ref-1">[RFC 1035 - Domain Names](https://www.ietf.org/rfc/rfc1035.txt)</a>

--- a/10-dns-bootstrap.md
+++ b/10-dns-bootstrap.md
@@ -32,6 +32,11 @@ In case of an IP class mismatch, e.g., the client asked for IPv4 addresses with 
 This MAY result in an empty reply, with the actual result in the extra section, and clients MUST handle it accordingly.
 The domain name returned in an `A` or `AAAA` reply MUST match the virtual hostname from the query in order not to be dropped by intermediate resolvers.
 
+## Policies
+
+The DNS seed MUST NOT return replies with a TTL lower than 60 seconds.
+The DNS seed MAY filter nodes from its local views for various reasons, including faulty nodes, flaky nodes, or spam prevention.
+Replies to random queries, i.e., queries to the seed root domain and the `_nodes._tcp.` alias for `SRV` queries, MUST be random samples from the set of all known good nodes and MUST NOT be biased.
 
 ## Examples
 

--- a/10-dns-bootstrap.md
+++ b/10-dns-bootstrap.md
@@ -6,14 +6,14 @@ Its purpose is twofold:
  - Bootstrap: the initial node discovery for nodes that have no known contacts in the network
  - Assisted Node Location: supporting nodes to discover the current network address previously known peers
 
-A domain name server implementing this specification is called a _DNS Seed_, and answers incoming DNS queries of type `A`, `AAAA` or `SRV` as specified in RFCs 1035<sub>[1](#ref-1)</sup>, 3596<sub>[2](#ref-2)</sup> and 2782<sub>[3](#ref-3)</sup> respectively.
+A domain name server implementing this specification is called a _DNS Seed_, and answers incoming DNS queries of type `A`, `AAAA` or `SRV` as specified in RFCs 1035<sup>[1](#ref-1)</sup>, 3596<sup>[2](#ref-2)</sup> and 2782<sup>[3](#ref-3)</sup> respectively.
 The DNS server is authoritative for a subdomain, called a _seed root domain_, and clients may query either the seed root domain or subdomains thereunder.
 
 ## Subdomain Structure
 
 A client MAY query the seed root domain for either `A`, `AAAA` or `SRV` records.
 Upon receiving `A` and `AAAA` queries the DNS seed MUST return a random subset of up to 25 IPv4 or IPv6 addresses of nodes that are listening for incoming connections on the default port 9735 as defined in [BOLT 01](01-messaging.md).
-In accordance with the Bitcoin DNS Seed policy<sub>[4](#ref-4)</sup> the DNS seed operator MAY NOT bias the result in any form, apart from filtering non-functioning or malicious nodes from the result.
+In accordance with the Bitcoin DNS Seed policy<sup>[4](#ref-4)</sup> the DNS seed operator MAY NOT bias the result in any form, apart from filtering non-functioning or malicious nodes from the result.
 The domain name associated with the addresses returned to `A` and `AAAA` queries MUST match the domain name in the query in order not to be filtered by intermediate resolvers.
 
 Upon receiving `SRV` queries the DNS seed MUST return a random subset of up to 5 (_virtual hostnames_, port)-tuples.
@@ -22,7 +22,7 @@ It is constructed by splitting the hex encoded `node_id` of the node into two pa
 The DNS seed MAY additionally return the corresponding `A` and `AAAA` indicating the IP address for the `SRV` entries in the Extra section of the reply.
 Due to the large size of the resulting reply it may happen that the reply is dropped by intermediate resolvers, hence the DNS seed MAY omit these additional records upon detecting a repeated query.
 The DNS seed MUST also allow the `_nodes._tcp.` subdomain for `SRV` queries.
-This is the standard compliant version as specified in RFC 2782<sub>[3](#ref-3).
+This is the standard compliant version as specified in RFC 2782<sup>[3](#ref-3)</sup>.
 
 A client MAY ask directly for the `A` or `AAAA` record for a specific node by querying for the virtual hostname.
 This may either be due to a previous `SRV` reply that omitted the extra section, or because the client is attempting to locate a specific node it was connected to before.


### PR DESCRIPTION
Thought I should finally write this up, and see if it people like it. The DNS seeds give us an easy way to bootstrap new nodes, encourage random connections and help nodes find previous peers again, should they get disconnected or change network.

This PR is still a bit thin on the policies side, but it has pointers to the Bitcoin DNS seed policy :wink: 
Also querying on features and realm could be interesting to add.

The risk in relying on the DNS seeds should be minimal. The queries get cached by the ISP, i.e., we do not see the client's IP or even how many in the ISP's network, and the authenticated encryption on the transport layer should prevent MitM attacks.

I'll polish my reference implementation a bit and link to it later.