### PR TITLE
[Trivial] Include a channel_update with the disable on temporary channel failure

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -533,6 +533,9 @@ If an otherwise unspecified transient error occurs for the outgoing
 channel (eg. peer unresponsive, channel capacity reached):
 
 1. type: 7 (`temporary_channel_failure`)
+2. data:
+   * [2:len]
+   * [len:channel_update]
 
 If an otherwise unspecified permanent error occurs for the outgoing
 channel (eg. channel (recently) closed):


### PR DESCRIPTION
Should be simple enough: if you fail a channel because it is temporarily unavailable, be nice enough to include the `channel_update` so we can spread the word