### PR TITLE
Acknowledgment of `temporary_channel_id`->`channel_id` switch

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -131,6 +131,8 @@ The 2-byte `len` field indicates the number of bytes in the immediately followin
 
 The channel is referred to by `channel-id` unless `channel-id` is zero (ie. all bytes zero), in which case it refers to all channels.
 
+The funding node MUST use `temporary-channel-id` in lieu of `channel-id` for all error messages sent before (and including) the `funding_created` message. The fundee node MUST use `temporary-channel-id` in lieu of `channel-id` for all error messages sent before (and not including) the `funding_signed` message.
+
 A node SHOULD send `error` for protocol violations or internal
 errors which make channels unusable or further communication unusable.
 A node MAY send an empty [data] field.  A node sending `error` MUST


### PR DESCRIPTION
The general idea is that starting from when it receives a `funding_created` message, the fundee should reply with the new final `channel_id`. But I think we need to specify better what should happen when things go wrong, because there can be a race under certain conditions. The fundee might send an `error` message with a `temporary_channel_id` to the funder even if the latter already sent a `funding_created` message.

We should probably specify that the fundee should use `temporary_channel_id` before it sends a `funding_signed` message, and `channel_id` after that. This means that it will reply with a `temporary_channel_id` if it is not happy with the proposed funding tx. We ran into this corner case during our tests when there was a huge discrepancy between funder/fundee fee estimates.