### PR TITLE
BOLT 4: Fix inconsistencies in error messages

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -275,3 +275,4 @@ metadata
 Bitcoin's
 Versioning
 checksum
+expiries

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -489,7 +489,7 @@ If the ephemeral key in the onion is unparsable:
 If an otherwise unspecified transient error occurs for the outgoing
 channel (eg. peer unresponsive, channel capacity reached):
 
-1. type: 7 (`temporary_channel_failure`)
+1. type: UPDATE|7 (`temporary_channel_failure`)
 2. data:
    * [`2`:`len`]
    * [`len`:`channel_update`]

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -487,7 +487,7 @@ If the ephemeral key in the onion is unparsable:
    * [`32`:`sha256_of_onion`]
 
 If an otherwise unspecified transient error occurs for the outgoing
-channel (eg. peer unresponsive, channel capacity reached):
+channel (eg. channel capacity reached, too many in-flight htlc):
 
 1. type: UPDATE|7 (`temporary_channel_failure`)
 2. data:
@@ -544,6 +544,15 @@ setting for the outgoing channel:
 
 1. type: UPDATE|14 (`expiry_too_soon`)
 2. data:
+   * [`2`:`len`]
+   * [`len`:`channel_update`]
+   
+If the channel is disabled, we tell them the the current channel
+setting for the outgoing channel:
+   
+1. type: UPDATE|20 (`channel_disabled`)
+2. data:
+   * [`2`: `flags`]
    * [`2`:`len`]
    * [`len`:`channel_update`]
 

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -166,6 +166,19 @@ Nodes forwarding HTLCs MUST construct the outgoing HTLC as specified within
 `per_hop`.  Otherwise, deviation from the specified HTLC parameters
 may lead to extraneous routing failure.
 
+### Payload for the last node
+
+The last node in the route could just discard its payload since it will not forward payments. However, when building the route, the original
+sender must use a payload for the last node with the following values:
+* `outgoing_cltv_value` is set to the final expiry specified by the recipient
+* `amt_to_forward` is set to the final amount specified by the recipient
+
+This way, the final node can check these values and return errors if needed, which will defeat probing attacks by the next to last node which could
+try to find out if the next node is the last one (by re-sending HTLCs with different amounts/expiries):
+
+The last node will extract its onion payload from the HTLC it has received and compare its values to the HTLC values.
+See the [Returning Errors](#returning-errors) section below for more details.
+
 ## Packet Construction
 
 Assuming a _sender node_ `n_0` wants to route a packet to a _final recipient_ `n_r`.
@@ -584,7 +597,7 @@ HTLC at the final hop:
 2. data:
    * [`4`:`cltv_expiry`]
 
-If the `amt_to_forward` does not match the `incoming_htlc_amt` of
+If the `amt_to_forward` is higher than `incoming_htlc_amt` of
 the HTLC at the final hop:
 
 1. type: 19 (`final_incorrect_htlc_amount`)


### PR DESCRIPTION
This follows a discussion started in #149. I am only proposing minimal changes, and individual commits are independant:
- https://github.com/lightningnetwork/lightning-rfc/commit/c07b276f7d0d87fc1efbd8f7ea3640a80793b7c1: since #149 added a mandatory `channel_update` message to `temporary_channel_failure`, then this error must have  the `UPDATE` flag
- https://github.com/lightningnetwork/lightning-rfc/commit/142e20769c828e93e7f540c61515cfb218216e91: since `channel_update` is fixed-size, we don't really need to provide its length (credits @cdecker)
- https://github.com/lightningnetwork/lightning-rfc/pull/167/commits/1736ae54960917890e33174838031fd87c79a335: since we already have `amount_below_minimum`, `fee_insufficient`, `incorrect_cltv_expiry` and `expiry_too_soon` errors when incoming htlcs do not comply with a specific field in `temporary_channel_failure`, we should also have a `channel_disabled` error for consistency reasons.

NB:
- in order to reduce the number of error messages, @cdecker also proposed to use a single type for `channel_update`-related errors, containing a bitfield to provide hints for the reason. It would also allow composing of errors. But unfortunately this wouldn't be compatible with providing fine-grain details, like what we do with `fee_insufficient`.`htlc_msat` or `incorrect_cltv_expiry`.`cltv_expiry`
- for the record I would have preferred only providing a `channel_update` when it actually explains the error (with specific error messages like we have currently), but @rustyrussell prefers always attaching one to `temporary_channel_failure` to [make failures provable](https://github.com/lightningnetwork/lightning-rfc/pull/149#issuecomment-298283452). With that in mind, I think a single `UPDATE` error message with a bitfield (that may be all zeroes) would make more sense, but I left that outside of this PR.

(I also tried [putting error messages in a table](https://github.com/pm47/lightning-rfc/commit/e6f61140b90c43f1bf34b5610c1925640979fb90), WDYT?)