### PR TITLE
Add support for announcing Tor onion service addresses 

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -274,3 +274,4 @@ timestamp
 metadata
 Bitcoin's
 Versioning
+checksum

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -194,10 +194,10 @@ The following `address descriptor` types are defined:
    * `0`: padding.  data = none (length 0).
    * `1`: ipv4. data = `[4:ipv4_addr][2:port]` (length 6)
    * `2`: ipv6. data = `[16:ipv6_addr][2:port]` (length 18)
-   * `3`: tor v2 onion service. data = `[10:onion_addr][2:port]` (length 18)
+   * `3`: tor v2 onion service. data = `[10:onion_addr][2:port]` (length 12)
        * Version 2 onion service addresses. Encodes an 80-bit truncated `SHA-1` hash
          of a 1024-bit `RSA` public key for the onion service.
-   * `4`: tor v3 onion service. data `[35:onion_addr][2:port]`  (length 36)
+   * `4`: tor v3 onion service. data `[35:onion_addr][2:port]`  (length 37)
        * Version 3 ([prop224](https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt))
          onion service addresses. Encodes: `[32:32_byte_ed25519_pubkey] || [2:checksum] || [1:version]`. 
              where `checksum = sha3(".onion checksum" | pubkey || version)[:2]`

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -194,6 +194,13 @@ The following `address descriptor` types are defined:
    * `0`: padding.  data = none (length 0).
    * `1`: ipv4. data = `[4:ipv4_addr][2:port]` (length 6)
    * `2`: ipv6. data = `[16:ipv6_addr][2:port]` (length 18)
+   * `3`: tor v2 onion service. data = `[10:onion_addr][2:port]` (length 18)
+       * Version 2 onion service addresses. Encodes an 80-bit truncated `SHA-1` hash
+         of a 1024-bit `RSA` public key for the onion service.
+   * `4`: tor v3 onion service. data `[35:onion_addr][2:port]`  (length 36)
+       * Version 3 ([prop224](https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt))
+         onion service addresses. Encodes: `[32:32_byte_ed25519_pubkey] || [2:checksum] || [1:version]`. 
+             where `checksum = sha3(".onion checksum" | pubkey || version)[:2]`
 
 ### Requirements
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -191,9 +191,9 @@ address type, followed by the appropriate number of bytes for that type.
 
 The following `address descriptor` types are defined:
 
-1. `0`: padding.  data = none (length 0).
-1. `1`: IPv4. data = `[4:ipv4_addr][2:port]` (length 6)
-2. `2`: IPv6. data = `[16:ipv6_addr][2:port]` (length 18)
+   * `0`: padding.  data = none (length 0).
+   * `1`: ipv4. data = `[4:ipv4_addr][2:port]` (length 6)
+   * `2`: ipv6. data = `[16:ipv6_addr][2:port]` (length 18)
 
 ### Requirements
 


### PR DESCRIPTION
This commit extends the set of define address descriptor types to
include support for v2 (current-gen) and v3 (next-gen) onion service
addresses. This enables user to run their Lightning nodes as onion
services, only accepting in-bound connections via their onion
addresses. Running a Lightning node behind Tor may serve to boost the
privacy of a user as they no longer need to give away their location
when advertising their node as willing to accept in-bound connections.

The current generation onion service address are widely deployed and
similar looking. They consume 10-bytes of space as they are the SHA-1
hash of a 1024-bit RSA public key. Encoding using base-32, they look
like: v2cbb2l4lsnpio4q.onion.

The next-generation onion services addresses are defined within
prop224_[1]. These addresses are a bit longer as they includes a full
e25519 public key (32-bytes), a 2-byte checksum, and finally a 1 byte
version. The full length of the raw version of these addresses are
35-bytes. When encoded using base-32, then next-gen onion address look
like: btojiu7nu5y5iwut64eufevogqdw4wmqzugnoluw232r4t3ecsfv37ad.onoin.

[1]: https://gitweb.torproject.org/torspec.git/tree/proposals/224-rend-spec-ng.txt