### PR TITLE
Allow a per-channel rather than per-session policy for announcing opened channels 

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -99,6 +99,7 @@ desire to set up a new channel.
    * [`33`:`payment_basepoint`]
    * [`33`:`delayed_payment_basepoint`]
    * [`33`:`first_per_commitment_point`]
+   * [`1`:`channel_flags`]
 
 
 The `chain_hash` value denotes the exact blockchain the opened channel will
@@ -112,6 +113,12 @@ The `temporary_channel_id` is used to identify this channel until the funding tr
 `max_htlc_value_in_flight_msat` is a cap on total value of outstanding HTLCs, which allows a node to limit its exposure to HTLCs; similarly `max_accepted_htlcs` limits the number of outstanding HTLCs the other node can offer. `channel_reserve_satoshis` is the minimum amount that the other node is to keep as a direct payment. `htlc_minimum_msat` indicates the smallest value HTLC this node will accept.
 
 `feerate_per_kw` indicates the initial fee rate by 1000-weight (ie. 1/4 the more normally-used 'feerate per kilobyte') which this side will pay for commitment and HTLC transactions as described in [BOLT #3](03-transactions.md#fee-calculation) (this can be adjusted later with an `update_fee` message).  `to_self_delay` is the number of blocks that the other nodes to-self outputs must be delayed, using `OP_CHECKSEQUENCEVERIFY` delays; this is how long it will have to wait in case of breakdown before redeeming its own funds.
+
+Only the least-significant bit of `channel_flags` is currently
+defined: `announce_channel`.  This indicates whether the initiator of the
+funding flow wishes to advertise this channel publicly to the network
+as detailed within
+[BOLT #7](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#bolt-7-p2p-node-and-channel-discovery).
 
 The `funding_pubkey` is the public key in the 2-of-2 multisig script of the funding transaction output.  The `revocation_basepoint` is combined with the revocation preimage for this commitment transaction to generate a unique revocation key for this commitment transaction. The `payment_basepoint` and `delayed_payment_basepoint` are similarly used to generate a series of keys for any payments to this node: `delayed_payment_basepoint` is used to for payments encumbered by a delay.  Varying these keys ensures that the transaction ID of each commitment transaction is unpredictable by an external observer, even if one commitment transaction is seen: this property is very useful for preserving privacy when outsourcing penalty transactions to third parties.
 
@@ -141,6 +148,10 @@ The sender SHOULD set `dust_limit_satoshis` to a sufficient value to
 allow commitment transactions to propagate through the Bitcoin
 network.  It SHOULD set `htlc_minimum_msat` to the minimum
 amount HTLC it is willing to accept from this peer.
+
+The receiving node MAY fail the channel if `announce_channel` is
+`false` (`0`), yet they wish to publicly announce the channel.  The
+receiving node MUST ignore undefined bits in `channel_flags`.
 
 The receiving node MUST accept a new `open_channel` message if the
 connection has been re-established after receiving a previous

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -442,7 +442,7 @@ reason to pay a premium for rapid processing.
 
 ## Normal Operation
 
-Once both nodes have exchanged `funding_locked` (and optionally `announcement_signatures`), the channel can be used to make payments via Hash TimeLocked Contracts.
+Once both nodes have exchanged `funding_locked` (and optionally [`announcement_signatures`](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#the-announcement_signatures-message)), the channel can be used to make payments via Hash TimeLocked Contracts.
 
 Changes are sent in batches: one or more `update_` messages are sent before a
 `commitment_signed` message, as in the following diagram:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -28,7 +28,7 @@ The willingness of the endpoints to announce the channel is signaled during the 
 
 ### Requirements
 
-If both endpoints have signaled that they'd like to publish the channel then the `announcement_signatures` message MUST be sent, otherwise they MUST NOT be sent.
+If the `open_channel` message had the `announce_channel` bit set, then both nodes must send the `announcement_signatures` message, otherwise they MUST NOT.
 
 If sent, `announcement_signatures` messages MUST NOT be sent until `funding_locked` has been sent, and the funding transaction is has at least 6 confirmations.
 

--- a/09-features.md
+++ b/09-features.md
@@ -17,7 +17,6 @@ These flags may only be used in the `init` message:
 
 | Bits | Name             |Description                                     | Link                                                                |
 |------|------------------|------------------------------------------------|---------------------------------------------------------------------|
-| 0/1  | `channels_public` | The sending node wishes to announce channels | [BOLT #7](07-routing-gossip.md#the-announcement_signatures-message) |
 | 3  | `initial_routing_sync` | The sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 
 ## Assigned `globalfeatures` flags
@@ -27,30 +26,11 @@ These flags may only be used in the `init` message:
 (Note that the requirements for feature bits which are not defined
 above, can be found in [BOLT #1: The `init` message](#the-init-message)).  The requirements when receiving set bits are defined in the linked section in the table above).
 
-Additional requirements:
-
-* `channels_public`: the sender MUST set exactly one of these bits if
-   it wants to announce the channel publicly, otherwise it MUST set
-   neither.  If it sets one it MUST set the even bit if it will fail the
-   connection if the other node does not also set one of the
-   `channels_public` bits, otherwise it MUST set the odd bit.  The
-   receiver MUST terminate the connection if neither `channels_public`
-   bit is set and it set the even `channels_public` bit on the `init`
-   message it sent, otherwise the receiver SHOULD treat either bit the
-   same.
-
 ## Rationale
 
 There's little point insisting on an `initial_routing_sync` (you can't
 tell if the remote node complies, and it has to know what it means as
 it's defined in the initial spec) so there's no even bit for that.
-
-There is a some point in insisting on channels being public: a node
-may not want to serve any private channels, and this gives clear
-indication, so that uses both bits.  You can read these bits as "odd:
-I would like the channel to be public" and "even: I require that the
-channel be public".
-
 
 ![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png "License CC-BY")
 <br>


### PR DESCRIPTION
This commit gives peers the ability to signal their intent to make a
channel private in the `open_channel` message. This differs from the
current method as now peers are able to create multiple channels with
heterogeneous announcement policies _without_ disconnecting and
re-connecting in-between each channel funding. The prior requirement
for the nodes to re-connect (in order to create a new channel with 
opposite policy of the active) was burdensome and unnecessary.

Additionally, it may not always be the case that upon _connection_ (but 
not yet funding workflow initiation), that a peer knows whether or not it 
wishes to advertise a connected channels. A peer may have originally 
connected just to receive gossip data, but then wishes to establish a 
channel. In this case, the node may need to _reconnect_ to apply their 
desired channel visibility to the to-be-opened channel. This PR 
eliminates this case, as the node is able to decide _when_ it starts 
a funding workflow, and isn't forced to decide before hand. 