### PR TITLE
BOLT 2,4,7: use 8 bytes for amounts, restrict add_htlc for bitcoin only.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -90,7 +90,7 @@ desire to set up a new channel.
    * [`8`:`dust_limit_satoshis`]
    * [`8`:`max_htlc_value_in_flight_msat`]
    * [`8`:`channel_reserve_satoshis`]
-   * [`4`:`htlc_minimum_msat`]
+   * [`8`:`htlc_minimum_msat`]
    * [`4`:`feerate_per_kw`]
    * [`2`:`to_self_delay`]
    * [`2`:`max_accepted_htlcs`]
@@ -195,8 +195,8 @@ acceptance of the new channel.
    * [`8`:`dust_limit_satoshis`]
    * [`8`:`max_htlc_value_in_flight_msat`]
    * [`8`:`channel_reserve_satoshis`]
+   * [`8`:`htlc_minimum_msat`]
    * [`4`:`minimum_depth`]
-   * [`4`:`htlc_minimum_msat`]
    * [`2`:`to_self_delay`]
    * [`2`:`max_accepted_htlcs`]
    * [`33`:`funding_pubkey`]
@@ -571,7 +571,7 @@ is destined, is described in [BOLT #4](04-onion-routing.md).
 2. data:
    * [`32`:`channel_id`]
    * [`8`:`id`]
-   * [`4`:`amount_msat`]
+   * [`8`:`amount_msat`]
    * [`4`:`cltv_expiry`]
    * [`32`:`payment_hash`]
    * [`1366`:`onion_routing_packet`]
@@ -585,6 +585,10 @@ Fees") while maintaining its channel reserve, MUST offer
 `amount_msat` greater than 0, MUST NOT offer `amount_msat` below
 the receiving node's `htlc_minimum_msat`, and MUST set `cltv_expiry` less
 than 500000000.
+
+For channels with `chain_hash` identifying the Bitcoin blockchain, the
+sending node MUST set the 4 most significant bytes of `amount_msat` to
+zero.
 
 A sending node MUST NOT add an HTLC if it would result in it offering
 more than the remote's `max_accepted_htlcs` HTLCs in the remote commitment
@@ -601,6 +605,10 @@ maintaining its channel reserve.  A receiving node SHOULD fail the
 channel if a sending node adds more than its `max_accepted_htlcs` HTLCs to
 its local commitment transaction, or adds more than its `max_htlc_value_in_flight_msat` worth of offered HTLCs to its local commitment transaction, or
 sets `cltv_expiry` to greater or equal to 500000000.
+
+For channels with `chain_hash` identifying the Bitcoin blockchain, the
+receiving node MUST fail the channel if the 4 most significant bytes
+of `amount_msat` are not zero.
 
 A receiving node MUST allow multiple HTLCs with the same payment hash.
 
@@ -638,6 +646,10 @@ as calculated in [BOLT #5](05-onchain.md#penalty-transaction-weight-calculation)
 
 `cltv_expiry` values equal or above 500000000 would indicate a time in
 seconds, and the protocol only supports an expiry in blocks.
+
+`amount_msat` is deliberately limited for this version of the
+specification; larger amounts are not necessary nor wise during the
+bootstrap phase of the network.
 
 ### Removing an HTLC: `update_fulfill_htlc`, `update_fail_htlc` and `update_fail_malformed_htlc`
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -572,8 +572,8 @@ is destined, is described in [BOLT #4](04-onion-routing.md).
    * [`32`:`channel_id`]
    * [`8`:`id`]
    * [`8`:`amount_msat`]
-   * [`4`:`cltv_expiry`]
    * [`32`:`payment_hash`]
+   * [`4`:`cltv_expiry`]
    * [`1366`:`onion_routing_packet`]
 
 

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -110,9 +110,9 @@ only `realm` 0 is defined, and for that, the `per_hop` format is:
 1. type: `per_hop` (for `realm` 0)
 2. data:
    * [`8`:`channel_id`]
-   * [`4`:`amt_to_forward`]
+   * [`8`:`amt_to_forward`]
    * [`4`:`outgoing_cltv_value`]
-   * [`16`:`padding`]
+   * [`12`:`padding`]
 
 Using the `per_hop`, the sender is able to precisely specify the path and
 structure of the HTLCs forwarded at each hop. As the `per_hop` is
@@ -514,7 +514,7 @@ the outgoing channel:
 
 1. type: UPDATE|11 (`amount_below_minimum`)
 2. data:
-   * [`4`:`htlc_msat`]
+   * [`8`:`htlc_msat`]
    * [`2`:`len`]
    * [`len`:`channel_update`]
 
@@ -524,7 +524,7 @@ channel:
 
 1. type: UPDATE|12 (`fee_insufficient`)
 2. data:
-   * [`4`:`htlc_msat`]
+   * [`8`:`htlc_msat`]
    * [`2`:`len`]
    * [`len`:`channel_update`]
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -276,7 +276,7 @@ it wants to change fees.
     * [`4`:`timestamp`]
     * [`2`:`flags`]
     * [`2`:`cltv_expiry_delta`]
-    * [`4`:`htlc_minimum_msat`]
+    * [`8`:`htlc_minimum_msat`]
     * [`4`:`fee_base_msat`]
     * [`4`:`fee_proportional_millionths`]
 


### PR DESCRIPTION
We had 4 byte fields for amounts because people have no ability to assess
risk, and this limited the damage to $70 at a time.

But then that means $1 maximum HTLCs on Litecoin, which isn't enough
for a cup of (decent) coffee.

Rather than have boutique hacks for Litecoin we enlarge the fields now,
and simply have a bitcoin-specific restriction that the upper 4 bytes be 0.

Suggested-by: Olaoluwa Osuntokun <laolu32@gmail.com>
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>