### PR TITLE
BOLT7: Add network view pruning

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -379,6 +379,20 @@ The node creating `channel_update` SHOULD accept HTLCs which pay an
 older fee for some time after sending `channel_update` to allow for
 propagation delay.
 
+## Pruning the Network View
+
+Nodes SHOULD monitor the funding transactions in the blockchain to identify channels that are being closed.
+If the funding output of a channel is being spent, then the channel is to be considered closed and SHOULD be removed from the local network view.
+
+Nodes MAY prune nodes added through `node_announcement` messages from their local view if the announced node no longer has any open channels associated.
+This is a direct result from the dependency of a `node_announcement` being preceeded by a `channel_announcement`,
+
+Several scenarios may result in channels becoming unusable and the endpoints unable to send updates for these channels.
+This happens for example in case that both endpoints lose access to their private keys, and cannot sign a `channel_update` or close the channel on-chain.
+These channels are unlikely to be part of a computed route since they would be partitioned off from the rest of the network, however they would remain in the local network view, and be forwarded to other nodes forever.
+For this reason nodes MAY prune channels should the timestamp of the latest `channel_update` be older than 2 weeks (1209600 seconds).
+In addition nodes MAY ignore channels with a timestamp older than 2 weeks.
+
 ## Recommendations for Routing
 
 As the fee is proportional, it must be calculated backwards from the

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -385,7 +385,7 @@ Nodes SHOULD monitor the funding transactions in the blockchain to identify chan
 If the funding output of a channel is being spent, then the channel is to be considered closed and SHOULD be removed from the local network view.
 
 Nodes MAY prune nodes added through `node_announcement` messages from their local view if the announced node no longer has any open channels associated.
-This is a direct result from the dependency of a `node_announcement` being preceeded by a `channel_announcement`,
+This is a direct result from the dependency of a `node_announcement` being preceded by a `channel_announcement`,
 
 Several scenarios may result in channels becoming unusable and the endpoints unable to send updates for these channels.
 This happens for example in case that both endpoints lose access to their private keys, and cannot sign a `channel_update` or close the channel on-chain.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -385,13 +385,16 @@ Nodes SHOULD monitor the funding transactions in the blockchain to identify chan
 If the funding output of a channel is being spent, then the channel is to be considered closed and SHOULD be removed from the local network view.
 
 Nodes MAY prune nodes added through `node_announcement` messages from their local view if the announced node no longer has any open channels associated.
-This is a direct result from the dependency of a `node_announcement` being preceded by a `channel_announcement`,
+This is a direct result from the dependency of a `node_announcement` being preceded by a `channel_announcement`.
+
+### Recommendation on pruning stale entries
 
 Several scenarios may result in channels becoming unusable and the endpoints unable to send updates for these channels.
 This happens for example in case that both endpoints lose access to their private keys, and cannot sign a `channel_update` or close the channel on-chain.
 These channels are unlikely to be part of a computed route since they would be partitioned off from the rest of the network, however they would remain in the local network view, and be forwarded to other nodes forever.
 For this reason nodes MAY prune channels should the timestamp of the latest `channel_update` be older than 2 weeks (1209600 seconds).
 In addition nodes MAY ignore channels with a timestamp older than 2 weeks.
+Notice that this is a node policy and MUST NOT be enforced by peers, e.g., by closing channels when receiving outdated gossip messages.
 
 ## Recommendations for Routing
 


### PR DESCRIPTION
Explicitly mentions that nodes SHOULD monitor the chain for channel
closes, and that a node MAY be removed if no open channels for that
node remain open.

Also mentions the 2 week lazy pruning we discussed on the call.

Closes #186