### PR TITLE
BOLT7: Reorder feature bitmaps in order to allow future changes

### DIFF
--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -89,6 +89,7 @@ for i,line in enumerate(fileinput.input(args)):
         if options.output_types:
             print("{},{}".format(match.group('name'), match.group('value')))
         havedata = None
+        alignoff = False
     elif message is not None and havedata is None:
         if line != '2. data:':
             message = None
@@ -101,7 +102,12 @@ for i,line in enumerate(fileinput.input(args)):
         if match:
             align = guess_alignment(message, match.group('name'), match.group('size'))
 
-            if options.check_alignment and dataoff % align != 0:
+            # Do not check alignment if we previously had a variable
+            # length field in the message
+            if off_extraterms != "":
+                alignoff = True
+
+            if not alignoff and options.check_alignment and dataoff % align != 0:
                 raise ValueError('{}:message {} field {} Offset {} not aligned on {} boundary:'.format(linenum, message, match.group('name'), dataoff, align))
 
             if options.output_fields:


### PR DESCRIPTION
Appending new fields to the end of the messages allows us to add new
fields to an existing message, however it does not allow removing
existing fields, e.g., dropping the pubkeys like #187 proposes. Moving
the features bitmap at the beginning of the signed payload allows
this type of change in the future. Nodes verify the integrity of the
message and then check whether there are any even bits they don't
implement. These even bits being required features would then result
in the message being discarded.

In addition to what we discussed during the call I also went ahead and
did the same reordering on `node_announcement`, which I think has the
same issue.

There is a subtle change in semantics, i.e., previously we would
add channels with unknown bits to our local view, but then ignore them
when computing a route. Now we no longer add them to our view, and may
discard the announcement altogether, stopping the broadcast. This is
safe I think since otherwise we'd be forwarding things we can only
verify the signatures of, but nothing else.