### PR TITLE
BOLT7: Allow channel_updates for non-public channels

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -276,7 +276,7 @@ in the `flags` field
 to indicate which end this is.  It can do this multiple times, if
 it wants to change fees.
 
-A node MAY still create a `channel_update` to communicate the channel parameters to the other endpoint, even though the channel has not been announced, e.g., because the `channels_public` bit was not set.
+A node MAY still create a `channel_update` to communicate the channel parameters to the other endpoint, even though the channel has not been announced, e.g., because the `announce_channel` bit was not set.
 For further privacy such a `channel_update` MUST NOT be forwarded to other peers.
 Note that such a `channel_update` that is not preceded by a `channel_announcement` is invalid to any other peer and would be discarded.
 


### PR DESCRIPTION
This was pointed out by @btcontract in #188: we need to communicate
our forwarding parameters even for private channels since otherwise
the other endpoint cannot use the private channel for incoming
routes. So we also accept `channel_update`s for our own channels even
for channels that were not announced publicly. Adds a bit of special
handling for our own channels in the gossip, but it is needed since
private channels would be completely unusable otherwise.

Fixes #188 