### PR TITLE
BOLT 2: closing tx fee clarifications

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -415,8 +415,8 @@ estimate of cost of inclusion in a block.
 
 The sender MUST set `signature` to the Bitcoin signature of the close
 transaction with the node responsible for paying the bitcoin fee
-paying `fee_satoshis`, without populating any output which is below
-its own `dust_limit_satoshis`. The sender MAY also eliminate its own
+paying `fee_satoshis`, then removing any output which is below
+its own `dust_limit_satoshis`. The sender MAY then also eliminate its own
 output from the mutual close transaction.
 
 The receiver MUST check `signature` is valid for either the close

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -408,7 +408,7 @@ Nodes SHOULD send a `closing_signed` message after `shutdown` has
 been received and no HTLCs remain in either commitment transaction.
 
 A sending node MUST set `fee_satoshis` lower than or equal to the
-fee of the final commitment transaction.
+base fee of the final commitment transaction as calculated in [BOLT #3](03-transactions.md#fee-calculation).
 
 The sender SHOULD set the initial `fee_satoshis` according to its
 estimate of cost of inclusion in a block.


### PR DESCRIPTION
1. You can't eliminate an output and also guarantee a certain fee, so
    we need to define exactly how to do this.

    Since the output is (presumably) dust, we might as well just discard it
    (effectively increasing the fee).  This avoids the peer directly benefiting
   from the elimination as well.

2. There are two final commitment transactions, which can be different if each side has a different
    dust level.  Make it clear that the max fee must be less or equal to the *base* fee, not the actual
    (post-output-elimination) fee.  This means it could be marginally higher than the final fee in theory,
    but in practice it's a tiny effect at worst.