### PR TITLE
BOLT 7: add chain_hash to channel_update and channel_announcement

### DIFF
--- a/00-introduction.md
+++ b/00-introduction.md
@@ -110,6 +110,17 @@ This is version 0.
      MUST support the feature in question, while odd numbers indicate
      that the feature MAY be disregarded by the other endpoint.
 
+
+* `chain_hash`:
+   * Used in several of the BOLT documents, and denotes the genesis hash of a
+     target blockchain. This allows nodes to create and reference channels on
+     several blockchains. Nodes are to ignore any messages which reference a
+     `chain_hash` that are unknown to them.
+
+     For the main chain Bitcoin blockchain, the `chain_hash` value MUST be
+     (encoded in hex):
+     `000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`.
+
 ## Theme Song
 
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -128,9 +128,7 @@ FIXME: Describe Dangerous feature bit for larger channel amounts.
 #### Requirements
 
 A sending node MUST ensure that the `chain_hash` value identifies the chain they
-they wish to open the channel within. For the Bitcoin blockchain, the
-`chain_hash` value MUST be (encoded in hex):
-`000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`.
+they wish to open the channel within.
 
 A sending node MUST ensure `temporary_channel_id` is unique from any other
 channel id with the same peer.  The sender MUST set `funding_satoshis`

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -317,8 +317,6 @@ The following table specifies the meaning of the individual bits:
 The creating node MUST set `signature` to the signature of the
 double-SHA256 of the entire remaining packet after `signature` using its own `node_id`.
 
-For the Bitcoin blockchain, the `chain_hash` value MUST be (encoded in
-hex): `000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`.
 The creating node MUST set `chain_hash` and `short_channel_id` to match the
 32-byte hash and 8-byte channel ID that uniquely identifies the channel within
 the `channel_announcement` message.  


### PR DESCRIPTION
This commit adds a 32-byte `chain_hash` value to both the
`channel_update` and `channel_announcement` messages. The rationale for
this change is that this value is already present within the
`open_channel` for identifying _which_ chain to open the channel
within. As is now, if a pair of peers had channels open on two chains
which somehow are encoded using the same `short_channel_id`, then the
announcements would be ambitious. We resolve this by explicitly
including the `chain_hash` is all channel related announcement
messages.

Note that with this change, we now require 40-bytes to uniquely
identify a channel globally.

Additionally, this modification of the channel announcement messages
allows peers to start building up a heterogenous network graph.