### PR TITLE
BOLT 11: fix formatting typo, and `r` length value.

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -149,8 +149,8 @@ indicate a sequence of non-public channels to traverse.
 A writer MUST pad field data to a multiple of 5 bits, using zeroes.
 
 A reader MUST skip over unknown fields, an `f` field with unknown
-`version`, or a `p`, `h`, `n` or `r` field which does not have ``data_length`` 52,
-52, 53 or 79 respectively.
+`version`, or a `p`, `h`, `n` or `r` field which does not have `data_length` 52,
+52, 53 or 82 respectively.
 
 A reader MUST check that the SHA-2 256 in the `h` field exactly
 matches the hashed description.

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -115,7 +115,7 @@ A writer MUST include exactly one `p` field, and set `payment_hash` to
 the SHA-2 256-bit hash of the `payment_preimage` which will be given
 in return for payment.
 
-A writer MUST NOT include more than one `d`, `h`, or `x` fields, and
+A writer MUST NOT include more than one `d`, `h`, `n` or `x` fields, and
 MAY include more than one `f` field.
 
 A writer MUST include either a `d` or `h` field, and MUST NOT include


### PR DESCRIPTION
The r field is 408 bytes long, which is 82 characters encoded;
this should have been updated when the fee and cltv sizes were
updated (prior to merge into repo).

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>