### PR TITLE
BOLT4: clarify that failure_code may reuse message type numbers

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -288,3 +288,4 @@ lollypop
 UTC
 inline
 fundee's
+BOLTs

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -444,9 +444,10 @@ The association between forward and return packet is handled outside of the prot
 
 The failure message encapsulated in `failuremsg` has identical format to
 a normal message: two byte type (`failure_code`) followed by data suitable
-for that type. The following `failure_code` values are supported.  A node MUST select one of
-these codes when creating an error message, and MUST include the
-appropriate data.
+for that type. The following `failure_code` values are supported.
+A node MUST select one of these codes when creating an error message, and MUST include the appropriate data.
+Notice that the `failure_code` are not message types defined in other BOLTs, not being sent directly on the transport layer, but wrapped inside an return packet.
+The numeric values for the `failure_code` may therefore reuse values that are also assigned as message types, without causing collisions.
 
 In the case of more than one error, a node SHOULD select the first one
 listed.


### PR DESCRIPTION
We reuse the numeric values that we previously assigned to message
types in the failure_code, but there is no possibility for a mixup
since the latter is not transmitted directly on the transport layer
but wrapped in a return packet. Hence there is no way of confusing the
two. Added a short clarification.

Reported-by: Janus Troelsen @ysangkok
Signed-off-by: Christian Decker <decker.christian@gmail.com>