### PR TITLE
BOLT 04: increase max size of onion payload messages

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -426,8 +426,8 @@ The node returning the message builds a return packet consisting of the followin
 
 Where `hmac` is an HMAC authenticating the remainder of the packet, with a key using the above key generation with key type "_um_", `failuremsg` is defined below, and `pad` as extra bytes to conceal length.
 
-The node SHOULD set `pad` such that the `failure_len` plus `pad_len` is equal to 128.
-This is 28 bytes longer than then the longest currently-defined message.
+The node SHOULD set `pad` such that the `failure_len` plus `pad_len` is equal to 256.
+This is 128 bytes longer than then the longest currently-defined message.
 
 The node then generates a new key, using the key type `ammag`.
 This key is then used to generate a pseudo-random stream, which is then applied to the packet using `XOR`.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -427,7 +427,7 @@ The node returning the message builds a return packet consisting of the followin
 Where `hmac` is an HMAC authenticating the remainder of the packet, with a key using the above key generation with key type "_um_", `failuremsg` is defined below, and `pad` as extra bytes to conceal length.
 
 The node SHOULD set `pad` such that the `failure_len` plus `pad_len` is equal to 256.
-This is 128 bytes longer than then the longest currently-defined message.
+This is 118 bytes longer than then the longest currently-defined message.
 
 The node then generates a new key, using the key type `ammag`.
 This key is then used to generate a pseudo-random stream, which is then applied to the packet using `XOR`.


### PR DESCRIPTION
This commit increases the max size of the encapsulated onion error
messages. This is a follow up change to the recent change that added a
`chain_hash` field to the `channel_update` message. With the addition of
this field, the largest payload encoded within the onion errors has
expanded to 138 bytes:

  * msat_amount || 2_byte_len || channel_update.

As a result, the old fixed limit (including padding) is now
insufficient. We use 256 bytes here in order to give us room for future
message expansions.