### PR TITLE
Spelling: expand wildcard to cover all []() patterns.

### DIFF
--- a/tools/spellcheck.sh
+++ b/tools/spellcheck.sh
@@ -50,7 +50,7 @@ for f
 do
     if [ -n "$CHECK" ]; then
 	# Eliminate the following:
-	# #-references eg. [Use of segwit](#use-of-segwit)
+	# Inline references eg. [Use of segwit](#use-of-segwit)
 	# quoted identifers eg. `htlc_id`
 	# field descriptions, eg. `* [`num_htlcs*64`:`htlc_signature]'
 	# indented field names, eg. '    `num_htlcs`: 0'
@@ -59,7 +59,7 @@ do
 	# Short hex strings, eg '0x2bb038521914'
 	# long hex strings
 	# long base58 strings
-	WORDS=$(sed -e 's/\](#[-a-zA-Z0-9_]*)//g' \
+	WORDS=$(sed -e 's/\]([-#a-zA-Z0-9_.]*)//g' \
 	    -e 's/`[a-zA-Z0-9_]*`//g' \
 	    -e 's/\* \[`[_a-z0-9*]\+`://g' \
 	    -e 's/0x[a-fA-F0-9]\+//g' \


### PR DESCRIPTION
Rusty pushed a trivial "update 00-Index" patch direct to master.  Rusty broke spellcheck.  Bad Rusty, bad.