### PR TITLE
Bolt11: specify that bech32 encoding should allow addresses > 90 chars

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -23,8 +23,10 @@ encoding.
 ## Requirements
 
 A writer MUST encode the the payment request in Bech32 as specified in
-BIP-0173.  A reader MUST parse the address as Bech32 as specified in
-BIP-0173, and MUST fail if the checksum is incorrect.
+BIP-0173, with the exception that the Bech32 string MAY be longer than
+the 90 characters specified there. A reader MUST parse the address as
+Bech32 as specified in BIP-0173 (also without the character limit),
+and MUST fail if the checksum is incorrect.
 
 # Human Readable Part
 


### PR DESCRIPTION
The current requirement says that "A writer MUST encode the the payment request in Bech32 as specified in BIP-0173. A reader MUST parse the address as Bech32 as specified in BIP-0173, and MUST fail if the checksum is incorrect.", but according to BIP-0173, strings are not allowed to be more than 90 characters long, which in the invoice case will happen.

This PR specifies this exception, to warn that existing bech32 encoding software might be incompatible.