### PR TITLE
BOLT 5: require to fail incoming HTLCs if HTLCs time out on chain.

### DIFF
--- a/05-onchain.md
+++ b/05-onchain.md
@@ -227,7 +227,9 @@ the payment preimage from the transaction input witness.
 
 
 If the HTLC output has *timed out* and not been *resolved*, the node
-MUST *resolve* the output.  If the transaction is the node's own
+MUST *resolve* the output and MUST fail the corresponding incoming
+HTLC (if any) once the resolving transaction has reached reasonable
+depth.  If the transaction is the node's own
 commitment transaction, it MUST *resolve* the output by spending it
 using the HTLC-timeout transaction, and the HTLC-timeout
 transaction output MUST be *resolved* as described in "On-chain HTLC


### PR DESCRIPTION
We talked about this below in the Rationale:

    The fulfillment of an on-chain HTLC delivers the `payment_preimage`
    required to fulfill the incoming HTLC...
    Otherwise, it needs to send the `update_fail_htlc` (presumably with
    reason `permanent_channel_failure`) as detailed in [BOLT
    02](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#forwarding-htlcs).

But we didn't actually *say* you MUST fail incoming HTLCs after reasonable
depth!

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>