### PR TITLE
Typo fix: CTLV -> CLTV.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -245,7 +245,6 @@ Poy
 talkin
 Freenode
 revocationkey
-ctlv
 msat
 func
 unencrypted

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -553,7 +553,7 @@ outgoing channel:
    * [`2`:`len`]
    * [`len`:`channel_update`]
 
-If the ctlv-expiry is too near, we tell them the the current channel
+If the cltv-expiry is too near, we tell them the the current channel
 setting for the outgoing channel:
 
 1. type: UPDATE|14 (`expiry_too_soon`)
@@ -591,7 +591,7 @@ If the `cltv_expiry` is too low, the final node MUST fail the HTLC:
 
 1. type: 17 (`final_expiry_too_soon`)
 
-If the `outgoing_cltv_value` does not match the `ctlv_expiry` of the
+If the `outgoing_cltv_value` does not match the `cltv_expiry` of the
 HTLC at the final hop:
 
 1. type: 18 (`final_incorrect_cltv_expiry`)


### PR DESCRIPTION
Locktime, not timelock.  Found this in my code, too, so pretty sure
it's my fault!

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>