### PR TITLE
BOLT 7,11: Added an optional `min_final_cltv_expiry` field in BOLT 11

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -110,6 +110,7 @@ I'th
 segwit
 htlc
 htlcs
+htlcs'
 ChaCha
 len
 ciphertext

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -109,6 +109,7 @@ hopDataSize
 I'th
 segwit
 htlc
+htlcs
 ChaCha
 len
 ciphertext

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -110,7 +110,6 @@ I'th
 segwit
 htlc
 htlcs
-htlcs'
 ChaCha
 len
 ciphertext

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -293,7 +293,7 @@ Note that the `channel_update` message is only useful in the context
 of *relaying* payments, not *sending* payments. When making a payment
  `A` -> `B` -> `C` -> `D`, only the `channel_update`s related to channels 
  `B` -> `C` (announced by `B`) and `C` -> `D` (announced by `C`) will 
- come into play. When building the route, htlcs' amounts and expiries need
+ come into play. When building the route, amounts and expiries for htlcs need
  to be calculated backwards from the destination to the source. The initial
  exact value for `amount_msat` and minimal value for `htlc_expiry`, which are
   to be used for the last htlc in the route, are provided in the payment request

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -293,7 +293,7 @@ Note that the `channel_update` message is only useful in the context
 of *relaying* payments, not *sending* payments. When making a payment
  `A` -> `B` -> `C` -> `D`, only the `channel_update`s related to channels 
  `B` -> `C` (announced by `B`) and `C` -> `D` (announced by `C`) will 
- come into play. When building the route, htlc's amounts and expiries need
+ come into play. When building the route, htlcs' amounts and expiries need
  to be calculated backwards from the destination to the source. The initial
  exact value for `amount_msat` and minimal value for `htlc_expiry`, which are
   to be used for the last htlc in the route, are provided in the payment request

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -296,7 +296,7 @@ of *relaying* payments, not *sending* payments. When making a payment
  come into play. When building the route, amounts and expiries for htlcs need
  to be calculated backwards from the destination to the source. The initial
  exact value for `amount_msat` and minimal value for `htlc_expiry`, which are
-  to be used for the last htlc in the route, are provided in the payment request
+  to be used for the last HTLC in the route, are provided in the payment request
  (see [BOLT #11](11-payment-encoding.md#tagged-fields)).
 
 A node MAY still create a `channel_update` to communicate the channel parameters to the other endpoint, even though the channel has not been announced, e.g., because the `announce_channel` bit was not set.

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -109,7 +109,7 @@ Currently defined Tagged Fields are:
 * `n` (19): `data_length` 53.  The 33-byte public key of the payee node.
 * `h` (23): `data_length` 52.  256-bit description of purpose of payment (SHA256).  This is used to commit to an associated description which is too long to fit, such as may be contained in a web page.
 * `x` (6): `data_length` variable.  `expiry` time in seconds (big-endian). Default is 3600 (1 hour) if not specified.
-* `c` (24): `data_length` (16 bits, big-endian). `min_final_cltv_expiry` to use for the last HTLC in the route. Default is 9 if not specified.
+* `c` (24): `data_length` variable. `min_final_cltv_expiry` to use for the last HTLC in the route. Default is 9 if not specified.
 * `f` (9): `data_length` variable, depending on version. Fallback on-chain address: for bitcoin, this starts with a 5 bit `version`; a witness program or P2PKH or P2SH address.
 * `r` (3): `data_length` variable.  One or more entries containing extra routing information for a private route; there may be more than one `r` field, too.
    * `pubkey` (264 bits)
@@ -129,11 +129,12 @@ the purpose of the payment.  If included, a writer MUST make the preimage
 of the hashed description in `h` available through some unspecified means,
 which SHOULD be a complete description of the purpose of the payment.
 
-A writer MAY include one `x` field, which SHOULD use the minimum `data_length` 
-possible.
+A writer MAY include one `x` field.
 
 A writer MAY include one `c` field, which MUST be set to the minimum `cltv_expiry` it
 will accept for the last HTLC in the route.
+
+A writer SHOULD use the minimum `data_length` possible for `x` and `c` fields.
 
 A writer MAY include one `n` field, which MUST be set to the public key
 used to create the `signature`.

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -109,7 +109,7 @@ Currently defined Tagged Fields are:
 * `n` (19): `data_length` 53.  The 33-byte public key of the payee node.
 * `h` (23): `data_length` 52.  256-bit description of purpose of payment (SHA256).  This is used to commit to an associated description which is too long to fit, such as may be contained in a web page.
 * `x` (6): `data_length` variable.  `expiry` time in seconds (big-endian). Default is 3600 (1 hour) if not specified.
-* `c` (24): `data_length` (16 bits, big-endian). `min_final_cltv` to use for the last HTLC in the route. Default is 9 if not specified.
+* `c` (24): `data_length` (16 bits, big-endian). `min_final_cltv_expiry` to use for the last HTLC in the route. Default is 9 if not specified.
 * `f` (9): `data_length` variable, depending on version. Fallback on-chain address: for bitcoin, this starts with a 5 bit `version`; a witness program or P2PKH or P2SH address.
 * `r` (3): `data_length` variable.  One or more entries containing extra routing information for a private route; there may be more than one `r` field, too.
    * `pubkey` (264 bits)

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -109,6 +109,7 @@ Currently defined Tagged Fields are:
 * `n` (19): `data_length` 53.  The 33-byte public key of the payee node.
 * `h` (23): `data_length` 52.  256-bit description of purpose of payment (SHA256).  This is used to commit to an associated description which is too long to fit, such as may be contained in a web page.
 * `x` (6): `data_length` variable.  `expiry` time in seconds (big-endian). Default is 3600 (1 hour) if not specified.
+* `c` (24): `data_length` (16 bits, big-endian). Minimum `cltv_expiry` to use for the last htlc. Default is 9 if not specified.
 * `f` (9): `data_length` variable, depending on version. Fallback on-chain address: for bitcoin, this starts with a 5 bit `version`; a witness program or P2PKH or P2SH address.
 * `r` (3): `data_length` variable.  One or more entries containing extra routing information for a private route; there may be more than one `r` field, too.
    * `pubkey` (264 bits)
@@ -130,6 +131,9 @@ which SHOULD be a complete description of the purpose of the payment.
 
 A writer MAY include one `x` field, which SHOULD use the minimum `data_length` 
 possible.
+
+A writer MAY include one `c` field, which MUST be set to the minimum `cltv_expiry` it
+will accept for the last htlc.
 
 A writer MAY include one `n` field, which MUST be set to the public key
 used to create the `signature`.
@@ -161,6 +165,10 @@ A reader MUST skip over unknown fields, an `f` field with unknown
 
 A reader MUST check that the SHA-2 256 in the `h` field exactly
 matches the hashed description.
+
+A reader MUST use a greater value for the last htlc's `cltv_expiry` than the one
+ in the `c` field if provided, and SHOULD follow the [shadow route recommendation](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#recommendations-for-routing)
+ on top of that.
 
 A reader MUST use the `n` field to validate the signature instead of
 performing signature recovery if a valid `n` field is provided.

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -166,9 +166,10 @@ A reader MUST skip over unknown fields, an `f` field with unknown
 A reader MUST check that the SHA-2 256 in the `h` field exactly
 matches the hashed description.
 
-A reader MUST use a greater value for the last htlc's `cltv_expiry` than the one
- in the `c` field if provided, and SHOULD follow the [shadow route recommendation](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#recommendations-for-routing)
- on top of that.
+A reader MUST use a greater value for the `cltv_expiry` of the last
+htlc than the one in the `c` field if provided, and SHOULD follow the 
+[shadow route recommendation](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#recommendations-for-routing) 
+on top of that.
 
 A reader MUST use the `n` field to validate the signature instead of
 performing signature recovery if a valid `n` field is provided.


### PR DESCRIPTION
This PR competes with #252.

It clarifies how `channel_update` messages are only to be used in the context of relaying payments, and how both htlc amounts and expiries are to be calculated backwards from the values provided in the payment request.

This means that we don't need the `channel_update` for the first channel in a route, which allows making a payment through a channel which hasn't had any announcements yet.

Note that the clever calculation leading to the default value of 9 for `min_final_cltv_expiry`
has been made in #253.
