### PR TITLE
Added IP Address field for payreqs to help opening channels

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -116,6 +116,7 @@ Currently defined Tagged Fields are:
    * `short_channel_id` (64 bits)
    * `fee` (64 bits, big-endian)
    * `cltv_expiry_delta` (16 bits, big-endian)
+* `a` (29): `data_length` 29.  IP (v4/v6) address information encoded in the same manner as the p2p protocol in Bitcoin. First 128 bits are the IP address encoded using  IPv4-mapped IPv6 address format. The last 16 bits are the port number. This can be used to fallback to opening a channel with the payee node. (used with n tag)
 
 ### Requirements
 


### PR DESCRIPTION
I like the fallback on-chain address field... but why not also include the IP address and allow the wallet to fallback to attempting a channel open message?

I would much rather have the wallet attempt to route a payment to me and if it didn't work, it should attempt to open a channel with me and push the funds in the opening commit.

There should be a way for the user to send the payment request hash in the openchannel message as well. That way I can connect the payreq I displayed to X user and the openchannel message I received as a fallback when payment routing failed.