### PR TITLE
BOLT-1: Minor line edits

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -298,3 +298,4 @@ htlckey
 remotehtlcsig
 localhtlcsig
 basepoints
+Bitcoins

--- a/00-introduction.md
+++ b/00-introduction.md
@@ -7,7 +7,7 @@ necessary.
 
 Some requirements are subtle; we have tried to highlight motivations
 and reasoning behind the results you see here. I'm sure we've fallen
-short: if you find any part confusing, or wrong, please contact us and
+short; if you find any part confusing or wrong, please contact us and
 help us improve.
 
 This is version 0.
@@ -25,86 +25,100 @@ This is version 0.
 
 ## Glossary and Terminology Guide
 
+* *Node*:
+   * A computer or other device connected to the Bitcoin network.
+
+
+* *Peers*:
+   * *Nodes* wanting to transact Bitcoins with each other through a *channel*.
+
+
 * *Funding transaction*:
-   * The on-chain, irreversible transaction that pays to both peers on a channel.
+   * An irreversible on-chain transaction that pays to both *peers* on a *channel*.
    It can only be spent by mutual consent.
 
 
 * *Channel*:
    * A fast, off-chain method of mutual exchange between two *peers*.
-   To move funds, peers exchange signatures for an updated *commitment transaction*.
+   To transact funds, peers exchange signatures to create an updated *commitment transaction*.
 
 
 * *Commitment transaction*:
-   * A transaction which spends the funding transaction.
-   Each peer holds the other peer's signature for this transaction, so that it
-   always has a commitment transaction it can spend. After a new
+   * A transaction that spends the *funding transaction*.
+   Each *peer* holds the other peer's signature for this transaction, so that each
+   always has a commitment transaction that it can spend. After a new
    commitment transaction is negotiated, the old one is *revoked*.
 
 
 * *HTLC*: Hashed Time Locked Contract.
-   * A conditional payment between two peers: the recipient can spend
+   * A conditional payment between two *peers*: the recipient can spend
     the payment by presenting its signature and a *payment preimage*,
     otherwise the payer can cancel the contract by spending it after
     a given time. These are implemented as outputs from the
     *commitment transaction*.
 
 
-* *Payment hash, payment preimage*:
-   * The HTLC contains the payment hash, which is the hash of the
-    payment preimage. Only the final recipient knows the payment
-    preimage. In order to release funds, the final recipient releases
-    the preimage as proof it has received payment.
+* *Payment hash*:
+   * The *HTLC* contains the payment hash, which is the hash of the
+    *payment preimage*. 
 
 
-* *Commitment revocation key*:
-   * Every *commitment transaction* has a unique *commitment revocation key*
-    value which allows the other peer to spend all outputs
+* *Payment preimage*: 
+   * Proof that payment has been received, held by
+    the final recipient, who is the only person who knows this
+    secret. The final recipient releases the preimage in order to
+    release funds. The payment preimage is hashes as the *payment hash*
+    in the *HTLC*.
+
+
+* *Commitment revocation secret key*:
+   * Every *commitment transaction* has a unique *commitment revocation* secret-key
+    value that allows the other *peer* to spend all outputs
     immediately: revealing this key is how old commitment
-    transactions are revoked. To do this, each output refers to the
-    commitment revocation pubkey.
+    transactions are revoked. To support revocation, each output of the 
+    commitment transaction refers to the commitment revocation public key.
 
 
 * *Per-commitment secret*:
-   * Every commitment derives its keys from a *per-commitment secret*,
+   * Every *commitment transaction* derives its keys from a per-commitment secret,
      which is generated such that the series of per-commitment secrets
      for all previous commitments can be stored compactly.
 
 
 * *Mutual close*:
-   * A cooperative close of a channel, by broadcasting an unconditional
-    spend of the *funding transaction* with an output to each peer
+   * A cooperative close of a *channel*, accomplished by broadcasting an unconditional
+    spend of the *funding transaction* with an output to each *peer*
     (unless one output is too small, and thus is not included).
 
 
 * *Unilateral close*:
-   * An uncooperative close of a channel, through broadcasting of a
+   * An uncooperative close of a *channel*, accomplished by broadcasting a
     *commitment transaction*. This transaction is larger (i.e. less
-    efficient) than a mutual close transaction, and the peer whose
+    efficient) than a *mutual close* transaction, and the peer whose
     commitment is broadcast cannot access its own outputs for some
     previously-negotiated duration.
 
 
 * *Revoked transaction close*:
-   * An invalid close of the channel, through broadcasting of a revoked
-    *commitment transaction*. Since the other peer knows the
+   * An invalid close of a *channel*, accomplished by broadcasting a revoked
+    *commitment transaction*. Since the other *peer* knows the
     *commitment revocation secret key*, it can create a *penalty transaction*.
 
 
 * *Penalty transaction*:
-   * A transaction which spends all outputs of a revoked commitment
-    transaction, using the *commitment revocation secret key*. A peer uses this
+   * A transaction that spends all outputs of a revoked *commitment
+    transaction*, using the *commitment revocation secret key*. A *peer* uses this
     if the other peer tries to "cheat" by broadcasting a revoked
     *commitment transaction*.
 
 
 * *Commitment number*:
    * A 48-bit incrementing counter for each *commitment transaction*; counters
-    are independent for each peer in the channel and start at 0.
+    are independent for each *peer* in the *channel* and start at 0.
 
 
 * *It's ok to be odd*:
-   * A rule applied to some numeric fields that indicates optional and
+   * A rule applied to some numeric fields that indicates either optional or
      compulsory support for features. Even numbers indicate that both endpoints
      MUST support the feature in question, while odd numbers indicate
      that the feature MAY be disregarded by the other endpoint.
@@ -112,8 +126,8 @@ This is version 0.
 
 * `chain_hash`:
    * Used in several of the BOLT documents to denote the genesis hash of a
-     target blockchain. This allows nodes to create and reference channels on
-     several blockchains. Nodes are to ignore any messages which reference a
+     target blockchain. This allows *nodes* to create and reference *channels* on
+     several blockchains. Nodes are to ignore any messages that reference a
      `chain_hash` that are unknown to them. Unlike `bitcoin-cli`, the hash is
      not reversed but is used directly.
 

--- a/00-introduction.md
+++ b/00-introduction.md
@@ -67,7 +67,7 @@ This is version 0.
    * Proof that payment has been received, held by
     the final recipient, who is the only person who knows this
     secret. The final recipient releases the preimage in order to
-    release funds. The payment preimage is hashes as the *payment hash*
+    release funds. The payment preimage is hashed as the *payment hash*
     in the *HTLC*.
 
 

--- a/01-messaging.md
+++ b/01-messaging.md
@@ -22,22 +22,22 @@ All data fields are big-endian unless otherwise specified.
 
 ## Connection Handling and Multiplexing
 
-Implementations MUST use a single connection per peer — channel messages (which include a channel ID) are multiplexed over this single connection.
+Implementations MUST use a single connection per peer; channel messages (which include a channel ID) are multiplexed over this single connection.
 
 ## Lightning Message Format
 
 After decryption, all Lightning messages are of the form:
 
-1. `type`: 2-byte big-endian field indicating the type of message.
-2. `payload`: variable length payload which comprises the remainder of
-   the message and conforms to the format matching the `type`.
+1. `type`: a 2-byte big-endian field indicating the type of message.
+2. `payload`: a variable-length payload that comprises the remainder of
+   the message and that conforms to a format matching the `type`.
 
 The `type` field indicates how to interpret the `payload` field.
-The format for each individual type is specified in a specification in this repository.
+The format for each individual type is defined by a specification in this repository.
 The type follows the _it's ok to be odd_ rule, so nodes MAY send _odd_-numbered types without ascertaining that the recipient understands it.
 
 A sending node:
-  - MUST NOT send an evenly-typed message not listed here, without prior negotiation.
+  - MUST NOT send an evenly-typed message not listed here without prior negotiation.
 
 A receiving node:
   - upon receiving a message of _odd_, unknown type:
@@ -45,26 +45,26 @@ A receiving node:
   - upon receiving a message of _even_, unknown type:
     - MUST fail the channels.
 
-The messages are grouped logically into four groups, ordered by their most significant set bit:
+The messages are grouped logically into four groups, ordered by the most significant bit that is set:
 
   - Setup & Control (types `0`-`31`): messages related to connection setup, control, supported features, and error reporting. These are described below.
   - Channel (types `32`-`127`): messages used to setup and tear down micropayment channels. These are described in [BOLT #2](02-peer-protocol.md).
-  - Commitment (types `128`-`255`): messages related to updating the current commitment transaction, which includes adding, revoking, and settling HTLCs, as well as updating fees and exchanging signatures. These are described in [BOLT #2](02-peer-protocol.md).
-  - Routing (types `256`-`511`): node and channel announcements, as well as any active route exploration. These are described in [BOLT #7](07-routing-gossip.md).
+  - Commitment (types `128`-`255`): messages related to updating the current commitment transaction, which includes adding, revoking, and settling HTLCs as well as updating fees and exchanging signatures. These are described in [BOLT #2](02-peer-protocol.md).
+  - Routing (types `256`-`511`): messages containing node and channel announcements, as well as any active route exploration. These are described in [BOLT #7](07-routing-gossip.md).
 
-The size of the message is required to fit into a 2-byte unsigned int by the transport layer; therefore, the maximum possible size is 65535 bytes.
+The size of the message is required by the transport layer to fit into a 2-byte unsigned int; therefore, the maximum possible size is 65535 bytes.
 
 A node:
-  - MUST ignore any additional data within a message, beyond the length it expects for that type.
+  - MUST ignore any additional data within a message beyond the length that it expects for that type.
   - upon receiving a known message with insufficient length for the contents:
     - MUST fail the channels.
-  - that understands an option (each is numbered):
+  - that understands a numbered option:
     - MUST include all the fields annotated with that option.
 
 ### Rationale
 
-The standard endian of `SHA2` and the encoding of Bitcoin public keys
-are big endian, thus it would be unusual to use a different endian for
+By default `SHA2` and Bitcoin public keys are both encoded as
+big endian, thus it would be unusual to use a different endian for
 other fields.
 
 Length is limited to 65535 bytes by the cryptographic wrapping, and
@@ -109,9 +109,9 @@ The sending node:
 The receiving node:
   - MUST wait to receive `init` before sending any other messages.
   - MUST respond to known feature bits as specified in [BOLT #9](09-features.md).
-  - upon receiving _odd_ feature bits which are non-zero:
+  - upon receiving _odd_ feature bits that are non-zero:
     - MUST ignore the bit.
-  - upon receiving _even_ feature bits which are non-zero:
+  - upon receiving _even_ feature bits that are non-zero:
     - MUST fail the connection.
 
 #### Rationale
@@ -119,11 +119,11 @@ The receiving node:
 This semantic allows both future incompatible changes and future backward compatible changes. Bits should generally be assigned in pairs, in order that optional features may later become compulsory.
 
 Nodes wait for receipt of the other's features to simplify error
-diagnosis, where features are incompatible.
+diagnosis when features are incompatible.
 
 The feature masks are split into local features (which only affect the
 protocol between these two nodes) and global features (which can affect
-HTLCs) and are thus also advertised to other nodes.
+HTLCs and are thus also advertised to other nodes).
 
 ### The `error` Message
 
@@ -152,7 +152,7 @@ The fundee node:
 A sending node:
   - when sending `error`:
     - MUST fail the channel referred to by the error message.
-  - SHOULD send `error` for protocol violations or internal errors which make channels unusable or further communication unusable.
+  - SHOULD send `error` for protocol violations or internal errors that make channels unusable or that make further communication unusable.
   - MAY send an empty `data` field.
   - when failure was caused by an invalid signature check:
     - SHOULD include the raw, hex-encoded transaction in reply to a `funding_created`, `funding_signed`, `closing_signed`, or `commitment_signed` message.
@@ -172,7 +172,7 @@ The receiving node:
 
 #### Rationale
 
-There are unrecoverable errors which require an abort of conversations;
+There are unrecoverable errors that require an abort of conversations;
 if the connection is simply dropped, then the peer may retry the
 connection. It's also useful to describe protocol violations for
 diagnosis, as this indicates that one peer has a bug.
@@ -239,9 +239,10 @@ is 65531 — in order to account for the type field (`pong`) and the `byteslen` 
 a convenient cutoff for `num_pong_bytes` to indicate that no reply should be sent.
 
 Connections between nodes within the network may be very long lived, as payment
-channels have an indefinite lifetime. However, it's likely that for a
-significant portion of the lifetime of a connection, no new data will be
-exchanged. Also, on several platforms it's possible that Lightning
+channels have an indefinite lifetime. However, it's likely that 
+no new data will be
+exchanged for a
+significant portion of a connection's lifetime. Also, on several platforms it's possible that Lightning
 clients will be put to sleep without prior warning. Hence, a
 distinct `ping` message is used, in order to probe for the liveness of the connection on
 the other side, as well as to keep the established connection active.
@@ -250,7 +251,7 @@ Additionally, the ability for a sender to request that the receiver send a
 response with a particular number of bytes enables nodes on the network to
 create _synthetic_ traffic. Such traffic can be used to partially defend
 against packet and timing analysis — as nodes can fake the traffic patterns of
-typical exchanges, without applying any true updates to their respective
+typical exchanges without applying any true updates to their respective
 channels.
 
 When combined with the onion routing protocol defined in


### PR DESCRIPTION
These are minor edits for BOLT-1, constrained to punctuation and minor word changes. In a few places clauses were rearranged. The changes were grammatical or for clarity.