### PR TITLE
BOLT 9: Adding missing option bits for option-dataloss-protect.

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -17,6 +17,7 @@ These flags may only be used in the `init` message:
 
 | Bits | Name             |Description                                     | Link                                                                |
 |------|------------------|------------------------------------------------|---------------------------------------------------------------------|
+| 0/1  | `option-data-loss-protect` | Requires/supports extra `channel_reestablish` fields | [BOLT #2](02-peer-protocol.md#message-retransmission) |
 | 3  | `initial_routing_sync` | The sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 | 4/5  | `option_upfront_shutdown_script` | Commit to a shutdown scriptpubkey when opening | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 


### PR DESCRIPTION
Somehow these got lost in merging; pre-approved at meeting 2017-11-27.

Reported-by: Pierre-Marie Padiou
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>