### PR TITLE
BOLT 1: options are no longer numbered.

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -58,7 +58,7 @@ A node:
   - MUST ignore any additional data within a message beyond the length that it expects for that type.
   - upon receiving a known message with insufficient length for the contents:
     - MUST fail the channels.
-  - that understands a numbered option:
+  - that understands an option in this specification:
     - MUST include all the fields annotated with that option.
 
 ### Rationale


### PR DESCRIPTION
Noticed when @shannona cleaned up this part of the spec.

(I had named the first option `option209` but that was too ugly to live.
Nonetheless, this wording lived on.)