### PR TITLE
Use remote's `htlc_minimum_msat` in `channel_update`

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -360,7 +360,7 @@ A node MAY create and send a `channel_update` with the `disable` bit set to sign
 A subsequent `channel_update` with the `disable` bit unset MAY re-enable the channel.
 
 The creating node MUST set `timestamp` to greater than zero, and MUST set it to greater than any previously-sent `channel_update` for this `short_channel_id`.
-It MUST set `cltv_expiry_delta` to the number of blocks it will subtract from an incoming HTLCs `cltv_expiry`. It MUST set `htlc_minimum_msat` to the minimum HTLC value it will accept, in millisatoshi. It MUST set `fee_base_msat` to the base fee it will charge for any HTLC, in millisatoshi, and `fee_proportional_millionths` to the amount it will charge per transferred satoshi in millionths of a satoshi.
+It MUST set `cltv_expiry_delta` to the number of blocks it will subtract from an incoming HTLCs `cltv_expiry`. It MUST set `htlc_minimum_msat` to the minimum HTLC value the other end of the channel will accept, in millisatoshi. It MUST set `fee_base_msat` to the base fee it will charge for any HTLC, in millisatoshi, and `fee_proportional_millionths` to the amount it will charge per transferred satoshi in millionths of a satoshi.
 
 The receiving nodes MUST ignore the `channel_update` if it does not correspond to one of its own channels, if the `short_channel_id` does not match a previous `channel_announcement`, or if the channel has been closed in the meantime.
 It SHOULD accept `channel_update`s for its own channels in order to learn the other end's forwarding parameters, even for non-public channels.


### PR DESCRIPTION
This is a consequence of commit d1fbfd30f8ad1463e4583466f0ff12fc4b582483: we now only use *outgoing* `channel_update` messages to build a route.

Basically the node publishing the `channel_update` says: I can only send htlcs > `htlc_minimum_msat` through this channel.

I think this is consistent with the current definition of the `amount_below_minimum` error (BOLT 4):
> If the HTLC does not reach the current minimum amount, we tell them the amount of the incoming HTLC and the current channel setting for the outgoing channel: