### PR TITLE
Removed HTLC-timeout for revoked tx handling

### DIFF
--- a/05-onchain.md
+++ b/05-onchain.md
@@ -417,7 +417,6 @@ A node MUST resolve all unresolved outputs as follows:
 3. _A's offered HTLCs_: The node MUST *resolve* this in one of three ways by spending: 
   * the *commitment tx* using the payment revocation
   * the *commitment tx* using the payment preimage if known
-  * the *HTLC-timeout tx* if B publishes them
 4. _B's offered HTLCs_: The node MUST *resolve* this in one of two ways by spending:
   * the *commitment tx* using the payment revocation
   * the *commitment tx* once the HTLC timeout has passed.


### PR DESCRIPTION
Publishing the remote's HTLC-timeout transactions is not needed anymore since #105.

Also, I wonder if "A's offered HTLCs"/"B's offered HTLCs" are inverted (see #286)?