### PR TITLE
BOLT3: the closing transaction now uses version 2

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -247,7 +247,7 @@ To spend this via penalty, the remote node uses a witness stack `<revocationsig>
 
 Note that there are two possible variants for each node.
 
-* version: 1
+* version: 2
 * locktime: 0
 * txin count: 1
    * `txin[0]` outpoint: `txid` and `output_index` from `funding_created` message


### PR DESCRIPTION
In this commit, we modify the cooperative closing transaction to use
version 2. Currently eclair and lnd already use version 2, while
c-lightning uses version 1. The commitment transaction already uses
version 2, so making this additional transaction (which spends the
funding output) also use version 2 would be consistent. Additionally,
as a best practice, we should be using the highest currently
defined/use transaction version.