### PR TITLE
BOLT 5: spell out each HTLC case (as a basis for more proofing)

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -301,3 +301,5 @@ localhtlcsig
 basepoints
 Bitcoins
 deobfuscate
+offerer
+offerer's


### PR DESCRIPTION
The proof-readers rightly noted how confusing the current treatment of
HTLCs is.  There are four different cases, but I tried to address them
in two separate sections, with conditionals.

This expands it out, separating sections for Our Commitment Tx and
Their Commitment Tx, then subsections for our HTLCs and their HTLCs
in each one.

It means some duplicated requirements and rationales, but it should now
be very clear.

As a side effect, we no longer refer to A and B at all: it's all US and THEM.
This needs further clearing up, but for now makes it clear what *we* need to do
for all cases.
