### PR TITLE
Typo: Remove duplicated word ("the")

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -22,7 +22,7 @@ encoding.
 
 ## Requirements
 
-A writer MUST encode the the payment request in Bech32 as specified in
+A writer MUST encode the payment request in Bech32 as specified in
 BIP-0173, with the exception that the Bech32 string MAY be longer than
 the 90 characters specified there. A reader MUST parse the address as
 Bech32 as specified in BIP-0173 (also without the character limit),


### PR DESCRIPTION
Remove duplicated word ("the").