### PR TITLE
Minor proselint edits

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -187,7 +187,7 @@ it leak information — hence, the optional `data` field.
 
 ### The `ping` and `pong` Messages
 
-In order to allow for the existence of very long-lived TCP connections, at
+In order to allow for the existence of long-lived TCP connections, at
 times it may be required that both ends keep alive the TCP connection at the
 application level. Such messages also allow obfuscation of traffic patterns.
 
@@ -241,7 +241,7 @@ The largest possible message is 65535 bytes; thus, the maximum sensible `bytesle
 is 65531 — in order to account for the type field (`pong`) and the `byteslen` itself. This allows
 a convenient cutoff for `num_pong_bytes` to indicate that no reply should be sent.
 
-Connections between nodes within the network may be very long lived, as payment
+Connections between nodes within the network may be long lived, as payment
 channels have an indefinite lifetime. However, it's likely that
 no new data will be
 exchanged for a

--- a/08-transport.md
+++ b/08-transport.md
@@ -42,7 +42,7 @@ conventions.
 The transcript between two nodes is separated into two distinct segments:
 
 1. First, before any actual data transfer, both nodes participate in an
-   authenticated key agreement handshake, which is based off of the Noise
+   authenticated key agreement handshake, which is based on the Noise
    Protocol Framework<sup>[2](#reference-2)</sup>.
 2. If the initial handshake is successful, then nodes enter the Lightning
    message exchange phase. In the Lightning message exchange phase, all

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -200,7 +200,7 @@ by changing the length, so readers ignore it if it's not 256 bits.
 The `n` field can be used to explicitly specify the destination node ID,
 instead of requiring signature recovery.
 
-The `x` field gives advance warning as to when a payment will be
+The `x` field gives warning as to when a payment will be
 refused; this is mainly to avoid confusion. The default was chosen
 to be reasonable for most payments and to allow sufficient time for
 on-chain payment if necessary.

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -1,6 +1,6 @@
 # BOLT #11: Invoice Protocol for Lightning Payments
 
-A simple, extensible QR-code-ready protocol for requesting payments
+A simple, extendable QR-code-ready protocol for requesting payments
 over Lightning.
 
 # Table of Contents

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -213,7 +213,7 @@ that remote nodes in the route specify their required `cltv_expiry_delta`
 in the `channel_update` message, which they can update at all times.
 
 The `f` field allows on-chain fallback. This may not make sense for
-tiny or very time-sensitive payments, however. It's possible that new
+tiny or time-sensitive payments, however. It's possible that new
 address forms will appear, and so multiple `f` fields in an implied
 preferred order help with transition, and `f` fields with versions 19-31
 will be ignored by readers.


### PR DESCRIPTION
Minor `proselint` edits:
* Standardization. Use "based on" instead of "based off of".
* Standardization. Use "extendable" instead of "extensible".
* Redundancy. Drop redundant use of "advance" in "advance warning".
* Redundancy. Drop redundant use of "very".