### PR TITLE
Add missing closing parenthesis. Use Markdown numbered list syntax.

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -52,7 +52,7 @@ The messages are grouped logically into four groups, ordered by the most signifi
   - Setup & Control (types `0`-`31`): messages related to connection setup, control, supported features, and error reporting (described below)
   - Channel (types `32`-`127`): messages used to setup and tear down micropayment channels (described in [BOLT #2](02-peer-protocol.md))
   - Commitment (types `128`-`255`): messages related to updating the current commitment transaction, which includes adding, revoking, and settling HTLCs as well as updating fees and exchanging signatures (described in [BOLT #2](02-peer-protocol.md))
-  - Routing (types `256`-`511`): messages containing node and channel announcements, as well as any active route exploration (described in [BOLT #7](07-routing-gossip.md)
+  - Routing (types `256`-`511`): messages containing node and channel announcements, as well as any active route exploration (described in [BOLT #7](07-routing-gossip.md))
 
 The size of the message is required by the transport layer to fit into a 2-byte unsigned int; therefore, the maximum possible size is 65535 bytes.
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -380,9 +380,9 @@ Nodes can negotiate a mutual close of the connection, which unlike a
 unilateral close, allows them to access their funds immediately and
 can be negotiated with lower fees.
 
-Closing happens in two stages: 1) one side indicates it wants to clear the channel
-(and thus will accept no new HTLCs) 2) once all HTLCs are resolved, the final channel close
-negotiation begins.
+Closing happens in two stages:
+1. one side indicates it wants to clear the channel (and thus will accept no new HTLCs)
+2. once all HTLCs are resolved, the final channel close negotiation begins.
 
         +-------+                              +-------+
         |       |--(1)-----  shutdown  ------->|       |


### PR DESCRIPTION
* Add missing closing parenthesis
* Use Markdown numbered list syntax (`1.` instead of `1)`)