### PR TITLE
[1.1] Add `funding_cancelled` message.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -306,3 +306,4 @@ offerer
 offerer's
 incentivize
 redemptions
+cancelled

--- a/09-features.md
+++ b/09-features.md
@@ -19,6 +19,7 @@ These flags may only be used in the `init` message:
 | 0/1  | `option-data-loss-protect` | Requires or supports extra `channel_reestablish` fields | [BOLT #2](02-peer-protocol.md#message-retransmission) |
 | 3  | `initial_routing_sync` | Indicates that the sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 | 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
+| 8/9  | `option-funding-cancelled` | Requires or supports `funding_cancelled` message | [BOLT #2](02-peer-protocol.md#the-funding_cancelled-message) |
 
 ## Assigned `globalfeatures` flags
 


### PR DESCRIPTION
This proposed new message indicates that the funding transaction can never confirm. For example, to implement replace-by-fee funding transactions, or to implement multi-channel funding transactions (see rationale of message for details).
  
This is inteded for BOLT 1.1