### PR TITLE
BOLT 2: clarify that feerate is in *satoshi* per ksipa.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -306,3 +306,4 @@ offerer
 offerer's
 incentivize
 redemptions
+vbytes

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -129,8 +129,8 @@ HTLCs, which allows a node to limit its exposure to HTLCs; similarly,
 `max_accepted_htlcs` limits the number of outstanding HTLCs the other
 node can offer.
 
-`feerate_per_kw` indicates the initial fee rate by 1000-weight
-(i.e. 1/4 the more normally-used 'fee rate per kilobyte') that this
+`feerate_per_kw` indicates the initial fee rate in satoshi per 1000-weight
+(i.e. 1/4 the more normally-used 'satoshi per 1000 vbytes') that this
 side will pay for commitment and HTLC transactions, as described in
 [BOLT #3](03-transactions.md#fee-calculation) (this can be adjusted
 later with an `update_fee` message).


### PR DESCRIPTION
We don't actually say that!

Closes: #336
Reported-by: Matt Corallo
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>