### PR TITLE
Note Possible Injection Vulnerabilities and Prevention Techniques

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -308,3 +308,10 @@ incentivize
 redemptions
 vbytes
 BTC
+XSS
+SQL
+DOM
+Javascript
+javascript
+Implementers
+sanitization

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -325,6 +325,23 @@ to be ordered in ascending order, unknown ones can be safely ignored.
 Future fields beyond `addresses` can still be added, optionally with
 padding within `addresses` if they require certain alignment.
 
+### Security Considerations for Node Aliases
+
+Node aliases are user-defined and provide a potential avenue for injection
+attacks, both in the process of rendering and persistence. 
+
+Node aliases should always be sanitized before being displayed in
+HTML/Javascript contexts, or any other dynamically interpreted rendering
+frameworks.  Similarly, consider using prepared statements, input validation,
+and/or escaping to protect against injection vulnerabilities against persistence
+engines that support SQL or other dynamically interpreted querying languages. 
+
+* [Stored and Reflected XSS Prevention](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet)
+* [DOM-based XSS Prevention](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet)
+* [SQL Injection Prevention](https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet)
+
+Don't be like the school of [Little Bobby Tables](https://xkcd.com/327/).
+
 ## The `channel_update` Message
 
 After a channel has been initially announced, each side independently

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -222,6 +222,28 @@ The `r` field allows limited routing assistance: as specified it only
 allows minimum information to use private channels, but it could also
 assist in future partial-knowledge routing.
 
+### Security Considerations for Payment Descriptions
+
+Payment descriptions are user-defined and provide a potential avenue for
+injection attacks, both in the process of rendering and persistence. 
+
+Payment descriptions should always be sanitized before being displayed in
+HTML/Javascript contexts, or any other dynamically interpreted rendering
+frameworks. Implementers should be extra perceptive to the possibility of
+reflected XSS attacks when decoding and displaying payment descriptions. Avoid
+optimistically rendering the contents of the payment request until all
+validation, verification, and sanitization have been successfully completed.
+
+Furthermore, consider using prepared statements, input validation, and/or
+escaping to protect against injection vulnerabilities against persistence
+engines that support SQL or other dynamically interpreted querying languages.
+
+* [Stored and Reflected XSS Prevention](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet)
+* [DOM-based XSS Prevention](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet)
+* [SQL Injection Prevention](https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet)
+
+Don't be like the school of [Little Bobby Tables](https://xkcd.com/327/).
+
 # Payer / Payee Interactions
 
 These are generally defined by the rest of the Lightning BOLT series,


### PR DESCRIPTION
This PR adds basic security recommendations for handling of node aliases and payment descriptions. Both fields are permitted to contain arbitrary user input, making them particularly susceptible to exploits via injection attacks if the input is controlled by an adversary. These commits make inline notes of the potential for these attacks if they are not properly mitigated and provide inline references for best practices in preventing various types of injection attacks.

If anyone has more resources to include or other relevant attacks that were missed, I would welcome more suggestions :) 