### PR TITLE
BOLT 3: closing tx must also round outputs down to whole satoshis.

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -261,6 +261,7 @@ Note that there are two possible variants for each node.
 ### Requirements
 
 Each node offering a signature:
+  - MUST round each output down to whole satoshis.
   - MUST subtract the fee given by `fee_satoshis` from the output to the funder.
   - MUST remove any output below its own `dust_limit_satoshis`.
   - MAY eliminate its own output.


### PR DESCRIPTION
We specify this for the commitment tx, but not for the closing tx.

Reported-by: Christian Decker
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>