### PR TITLE
Distinguish between static and ephemeral public keys. Reference cleanup.

### DIFF
--- a/08-transport.md
+++ b/08-transport.md
@@ -53,7 +53,7 @@ The transcript between two nodes is separated into two distinct segments:
 The handshake chosen for the authenticated key exchange is `Noise_XK`. As a
 pre-message, the initiator must know the identity public key of
 the responder. This provides a degree of identity hiding for the
-responder, as its public key is _never_ transmitted during the handshake. Instead,
+responder, as its static public key is _never_ transmitted during the handshake. Instead,
 authentication is achieved implicitly via a series of Elliptic-Curve
 Diffie-Hellman (ECDH) operations followed by a MAC check.
 

--- a/08-transport.md
+++ b/08-transport.md
@@ -152,7 +152,7 @@ The following functions will also be referenced:
       * The returned value is the SHA256 of the DER-compressed format of the
 	    generated point.
 
-  * `HKDF(salt,ikm)`: a function defined in [3](#reference-3), evaluated with a
+  * `HKDF(salt,ikm)`: a function defined in `RFC 5869`<sup>[3](#reference-3)</sup>, evaluated with a
     zero-length `info` field
      * All invocations of `HKDF` implicitly return 64 bytes of
        cryptographic randomness using the extract-and-expand component of the


### PR DESCRIPTION
* Distinguish between static and ephemeral public keys
* Use consistent method for referencing RFC:s