### PR TITLE
Fix markdownlint warnings

### DIFF
--- a/.copy-edit-stylesheet-checklist.md
+++ b/.copy-edit-stylesheet-checklist.md
@@ -1,5 +1,6 @@
-Basic checklist/stylesheet used for copy editing BOLTs —
-temporarily included here for reference purposes.
+# Basic checklist/stylesheet used for copy editing BOLTs
+
+This checklist/stylesheet is temporarily included here for reference purposes.
 
   - spelling
   - typos
@@ -46,7 +47,6 @@ temporarily included here for reference purposes.
     - for calculation descriptions
       - write out operators
         - e.g. 1 less than 3 equals 2
-    -
   - list structure
     - 2 spaces before item
     - indent 2 spaces

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -157,8 +157,7 @@ for the first commitment transaction,
 Only the least-significant bit of `channel_flags` is currently
 defined: `announce_channel`. This indicates whether the initiator of
 the funding flow wishes to advertise this channel publicly to the
-network, as detailed within [BOLT
-#7](07-routing-gossip.md#bolt-7-p2p-node-and-channel-discovery).
+network, as detailed within [BOLT #7](07-routing-gossip.md#bolt-7-p2p-node-and-channel-discovery).
 
 The `shutdown_scriptpubkey` allows the sending node to commit to where
 funds will go on mutual close, which the remote node should enforce


### PR DESCRIPTION
Fixed `markdownlint` warnings:

```
.copy-edit-stylesheet-checklist.md: 49: MD030/list-marker-space Spaces after list markers [Expected: 1; Actual: 0]
.copy-edit-stylesheet-checklist.md: 1: MD041/first-line-h1 First line in file should be a top level header [Context: "Basic checklist/stylesheet use..."]
02-peer-protocol.md: 161: MD018/no-missing-space-atx No space after hash on atx style header [Context: "#7](07-routing-gossip.md#bolt-..."]
```