### PR TITLE
BOLT 4: Clarify the onion construction and suggest optimization.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -324,3 +324,4 @@ ecdhResult
 scalarMult
 blindingFactor
 Mul
+unlinkable

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -315,3 +315,5 @@ Javascript
 javascript
 Implementers
 sanitization
+ek
+reblind

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -317,3 +317,10 @@ Implementers
 sanitization
 ek
 reblind
+ephemeralKey
+ephemeralPrivKey
+ephemeralPubKey
+ecdhResult
+scalarMult
+blindingFactor
+Mul

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -280,7 +280,9 @@ The transformations at hop `k` are as follows:
 
  - The shared secret `ss_k` is computed by first blinding the hop's public key
  `nodepk_k` with all previous blinding factors `{b_1, ..., b_{k-1}}` (if any),
- and second, executing ECDH with the blinded public key and the `sessionkey`.
+ and second, executing ECDH with the blinded public key and the `sessionkey` to
+ obtain a group element. The shared secret `ss_k` is then calculated as the
+ `SHA256` hash of the ECDH output, serialized in the compressed format.
  - The blinding factor is the `SHA256` hash of the concatenation between the
  hop's public key `nodepk_k` and its shared secret `ss_k`. Before
  concatenation, the hop's public key is serialized in the compressed format.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -284,8 +284,8 @@ The transformations at hop `k` are as follows:
  obtain a group element. The shared secret `ss_k` is then calculated as the
  `SHA256` hash of the ECDH output, serialized in the compressed format.
  - The blinding factor is the `SHA256` hash of the concatenation between the
- hop's public key `nodepk_k` and its shared secret `ss_k`. Before
- concatenation, the hop's public key is serialized in the compressed format.
+ ephemeral public key `epk_k` and the shared secret `ss_k`. Before
+ concatenation, the ephemeral public key is serialized in the compressed format.
  - The ephemeral public key `epk_k` is computed by blinding the hop's sending
  peer's ephemeral public key `epk_{k-1}` with the hop's sending peer's blinding
  factor `b_{k-1}`.
@@ -559,15 +559,15 @@ any further and thus need not extract an HMAC either.
 
 In order to vary the ephemeral public key (the EC point) between hops, it's
 blinded at each hop.
-The inputs for the blinding process are the EC point to be blinded, the hop's
-public key, and a 32-byte shared secret. The output is a single EC point, which
-represents the blinded element.
+The inputs for the blinding process are the EC point to be blinded and a 32-byte
+shared secret. The output is a single EC point, which represents the blinded
+element.
 
-Blinding is accomplished by computing a blinding factor from the hop's public
-key and the shared secret for that hop.
+Blinding is accomplished by computing a blinding factor from the ephemeral
+public key and the shared secret for that hop.
 The blinding factor is the computed `SHA256` hash value of the result of
-serializing the hop's public key into its compressed format and appending the
-shared secret.
+serializing the ephemeral public key into its compressed format and appending
+the shared secret.
 The blinded EC point, in turn, is the result of the scalar multiplication of the
 EC point and the blinding factor.
 


### PR DESCRIPTION
As was noted in by @cfromknecht [on the mailing list](https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-February/000981.html), the current spec suggests a quadratic time algorithm for onion packet construction, while a linear time one is possible.

I have reworded the relevant section to introduce the concept of an ephemeral private key, which I find easier to reason about and suggests the linear time algorithm.

As a separate change that may be worth putting in a separate pull request instead, the instructions for deriving the shared secret is incomplete in that it only says to perform ECDH, but not to take the SHA256 hash of the serialized point. All implementations do this, as does the reference code in the spec. Also, the blinding factor calculation instructions had a mistake.