### PR TITLE
Change "if" to "so that" to make sense 

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -54,7 +54,7 @@ The following `multiplier` letters are defined:
 
 ## Requirements
 
-A writer MUST include `amount` if payments will be refused if less
+A writer MUST include `amount` so that payments will be refused if less
 than that. A writer MUST encode `amount` as a positive decimal
 integer with no leading zeroes and SHOULD use the shortest representation
 possible.


### PR DESCRIPTION
There were double "if" and it didn't make sense to me. I modified the sentence so now does it make sense?