### PR TITLE
BOLT 2: ensure that we always have a non-dust output.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -211,6 +211,8 @@ The receiving node MUST fail the channel if:
   - `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, or `delayed_payment_basepoint`
 are not valid DER-encoded compressed secp256k1 pubkeys.
   - `dust_limit_satoshis` is greater than `channel_reserve_satoshis`.
+  - the funder's amount for the initial commitment transaction is sufficient for [fee payment](03-transactions.md#fee-payment).
+  - both `to_local` and `to_remote` amounts for the initial commitment transaction are less than or equal to `channel_reserve_satoshis`.
 
 The receiving node MUST NOT:
   - consider funds received, using `push_msat`, to be received until the funding transaction has reached sufficient depth.
@@ -223,7 +225,7 @@ Specifically, [the routing gossip protocol](07-routing-gossip.md) does not disca
 
 The *channel reserve* is specified by the peer's `channel_reserve_satoshis`: 1% of the channel total is suggested. Each side of a channel maintains this reserve so it always has something to lose if it were to try to broadcast an old, revoked commitment transaction. Initially, this reserve may not be met, as only one side has funds; but the protocol ensures that there is always progress toward meeting this reserve, and once met, it is maintained.
 
-The sender can unconditionally give initial funds to the receiver using a non-zero `push_msat` — this is one case where the normal reserve mechanism doesn't apply. However, like any other on-chain transaction, this payment is not certain until the funding transaction has been confirmed sufficiently (with a danger of double-spend until this occurs) and may require a separate method to prove payment via on-chain confirmation.
+The sender can unconditionally give initial funds to the receiver using a non-zero `push_msat`, but even in this case we ensure that the funder has sufficient remaining funds to pay fees and that one side has some amount it can spend (which also implies there is at least one non-dust output). Note that, like any other on-chain transaction, this payment is not certain until the funding transaction has been confirmed sufficiently (with a danger of double-spend until this occurs) and may require a separate method to prove payment via on-chain confirmation.
 
 The `feerate_per_kw` is generally only of concern to the sender (who pays the fees), but there is also the fee rate paid by HTLC transactions; thus, unreasonably large fee rates can also penalize the recipient.
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -231,7 +231,9 @@ Separating the `htlc_basepoint` from the `payment_basepoint` improves security: 
 
 The requirement that `channel_reserve_satoshis` is not considered dust
 according to `dust_limit_satoshis` eliminates cases where all outputs
-would be eliminated as dust.
+would be eliminated as dust.  The similar requirements in
+`accept_channel` ensure that both sides' `channel_reserve_satoshis`
+are above both `dust_limit_satoshis`.
 
 #### Future
 
@@ -272,6 +274,8 @@ the `open_channel` message.
 The sender:
   - SHOULD set `minimum_depth` to a number of blocks it considers reasonable to
 avoid double-spending of the funding transaction.
+  - MUST set `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis` from the `open_channel` message.
+  - MUST set `dust_limit_satoshis` less than `channel_reserve_satoshis` from th `open_channel` message.
 
 The receiver:
   - if the `chain_hash` value, within the `open_channel`, message is set to a hash
@@ -279,7 +283,10 @@ The receiver:
     - MUST reject the channel.
   - if `minimum_depth` is unreasonably large:
     - MAY reject the channel.
-
+  - if `channel_reserve_satoshis` is less than `dust_limit_satoshis` within the `open_channel` message:
+	- MUST reject the channel.
+  - if `channel_reserve_satoshis` from the `open_channel` message is less than `dust_limit_satoshis`:
+	- MUST reject the channel.
 Other fields have the same requirements as their counterparts in `open_channel`.
 
 ### The `funding_created` Message

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -211,7 +211,7 @@ The receiving node MUST fail the channel if:
   - `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, or `delayed_payment_basepoint`
 are not valid DER-encoded compressed secp256k1 pubkeys.
   - `dust_limit_satoshis` is greater than `channel_reserve_satoshis`.
-  - the funder's amount for the initial commitment transaction is sufficient for [fee payment](03-transactions.md#fee-payment).
+  - the funder's amount for the initial commitment transaction is not sufficient for full [fee payment](03-transactions.md#fee-payment).
   - both `to_local` and `to_remote` amounts for the initial commitment transaction are less than or equal to `channel_reserve_satoshis`.
 
 The receiving node MUST NOT:

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -174,6 +174,7 @@ The sending node:
   - MUST set `push_msat` to equal or less than 1000 * `funding_satoshis`.
   - MUST set `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, and `delayed_payment_basepoint` to valid DER-encoded, compressed, secp256k1 pubkeys.
   - MUST set `first_per_commitment_point` to the per-commitment point to be used for the initial commitment transaction, derived as specified in [BOLT #3](03-transactions.md#per-commitment-secret-requirements).
+  - MUST `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis`.
   - MUST set undefined bits in `channel_flags` to 0.
   - if both nodes advertised the `option_upfront_shutdown_script` feature:
     - MUST include either a valid `shutdown_scriptpubkey` as required by `shutdown` `scriptpubkey`, or a zero-length `shutdown_scriptpubkey`.
@@ -209,6 +210,7 @@ The receiving node MUST fail the channel if:
   - it considers `feerate_per_kw` too small for timely processing or unreasonably large.
   - `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, or `delayed_payment_basepoint`
 are not valid DER-encoded compressed secp256k1 pubkeys.
+  - `dust_limit_satoshis` is greater than `channel_reserve_satoshis`.
 
 The receiving node MUST NOT:
   - consider funds received, using `push_msat`, to be received until the funding transaction has reached sufficient depth.
@@ -226,6 +228,10 @@ The sender can unconditionally give initial funds to the receiver using a non-ze
 The `feerate_per_kw` is generally only of concern to the sender (who pays the fees), but there is also the fee rate paid by HTLC transactions; thus, unreasonably large fee rates can also penalize the recipient.
 
 Separating the `htlc_basepoint` from the `payment_basepoint` improves security: a node needs the secret associated with the `htlc_basepoint` to produce HTLC signatures for the protocol, but the secret for the `payment_basepoint` can be in cold storage.
+
+The requirement that `channel_reserve_satoshis` is not considered dust
+according to `dust_limit_satoshis` eliminates cases where all outputs
+would be eliminated as dust.
 
 #### Future
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -277,7 +277,7 @@ The sender:
   - SHOULD set `minimum_depth` to a number of blocks it considers reasonable to
 avoid double-spending of the funding transaction.
   - MUST set `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis` from the `open_channel` message.
-  - MUST set `dust_limit_satoshis` less than `channel_reserve_satoshis` from th `open_channel` message.
+  - MUST set `dust_limit_satoshis` less than `channel_reserve_satoshis` from the `open_channel` message.
 
 The receiver:
   - if the `chain_hash` value, within the `open_channel`, message is set to a hash

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -277,7 +277,7 @@ The sender:
   - SHOULD set `minimum_depth` to a number of blocks it considers reasonable to
 avoid double-spending of the funding transaction.
   - MUST set `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis` from the `open_channel` message.
-  - MUST set `dust_limit_satoshis` less than `channel_reserve_satoshis` from the `open_channel` message.
+  - MUST set `dust_limit_satoshis` less than or equal to `channel_reserve_satoshis` from the `open_channel` message.
 
 The receiver:
   - if the `chain_hash` value, within the `open_channel`, message is set to a hash

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -174,7 +174,7 @@ The sending node:
   - MUST set `push_msat` to equal or less than 1000 * `funding_satoshis`.
   - MUST set `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, and `delayed_payment_basepoint` to valid DER-encoded, compressed, secp256k1 pubkeys.
   - MUST set `first_per_commitment_point` to the per-commitment point to be used for the initial commitment transaction, derived as specified in [BOLT #3](03-transactions.md#per-commitment-secret-requirements).
-  - MUST `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis`.
+  - MUST set `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis`.
   - MUST set undefined bits in `channel_flags` to 0.
   - if both nodes advertised the `option_upfront_shutdown_script` feature:
     - MUST include either a valid `shutdown_scriptpubkey` as required by `shutdown` `scriptpubkey`, or a zero-length `shutdown_scriptpubkey`.


### PR DESCRIPTION
~~This requirement is subtle: firstly, we ensure that both reserve values are above
both dust limits.  But we also need to make sure that fees (which can eat into
reserves) always leave enough left: it makes sense to ensure that worst-case
fees are actually covered by the channel capacity, otherwise the channel is
likely to be useless anyway.~~

I re-read the fee payment section: we can simply assert that reserves are above dust.
