### PR TITLE
BOLT-0 Glossary Reorg & Expansion

### DIFF
--- a/00-introduction.md
+++ b/00-introduction.md
@@ -29,8 +29,8 @@ This is version 0.
    * A gossip message sent between *peers* intended to aid the discovery of a *channel* or a *node*.
 
 * `chain_hash`:
-   * The genesis hash of a
-     target blockchain. This allows *nodes* to create and reference *channels* on
+   * The uniquely identifying hash of the target blockchain (usually the genesis hash).
+     This allows *nodes* to create and reference *channels* on
      several blockchains. Nodes are to ignore any messages that reference a
      `chain_hash` that are unknown to them. Unlike `bitcoin-cli`, the hash is
      not reversed but is used directly.
@@ -42,7 +42,7 @@ This is version 0.
 * *Channel*:
    * A fast, off-chain method of mutual exchange between two *peers*.
    To transact funds, peers exchange signatures to create an updated *commitment transaction*.
-   * _See closure methods: mutal close, revoked transaction close, unilateral close_
+   * _See closure methods: mutual close, revoked transaction close, unilateral close_
 
 * *Closing transaction*:
    * A transaction generated as part of a _mutual close_. A closing transaction is similar to a _commitment transaction_, but with no pending payments.
@@ -83,7 +83,7 @@ This is version 0.
    * _See related: closing transaction, commitment transaction, penalty transaction_
 
 * *Hop*:
-   * A *node*. Generally, an intermmediate node lying between an *origin node* and a *final node*.
+   * A *node*. Generally, an intermediate node lying between an *origin node* and a *final node*.
    * _See category: node_
 
 * *HTLC*: Hashed Time Locked Contract.
@@ -178,7 +178,7 @@ This is version 0.
    * An invalid close of a *channel*, accomplished by broadcasting a *revoked
     commitment transaction*. Since the other *peer* knows the
     *commitment revocation secret key*, it can create a *penalty transaction*.
-   * _See related: mutal close, unilateral close_
+   * _See related: mutual close, unilateral close_
 
 * *Sending node*: 
    * A *node* that is sending a message.

--- a/00-introduction.md
+++ b/00-introduction.md
@@ -114,7 +114,7 @@ This is version 0.
    * A cooperative close of a *channel*, accomplished by broadcasting an unconditional
     spend of the *funding transaction* with an output to each *peer*
     (unless one output is too small, and thus is not included).
-   * _See related: revoked transaction close, unilateral close__
+   * _See related: revoked transaction close, unilateral close_
 
 * *Node*:
    * A computer or other device that is part of the Lightning network.
@@ -179,7 +179,7 @@ This is version 0.
 * *Revoked commitment transaction*:
    * An old *commitment transaction* that has been revoked because a new commitment transaction has been negotiated.
    * _See category: commitment transaction_
-   
+
 * *Revoked transaction close*:
    * An invalid close of a *channel*, accomplished by broadcasting a *revoked
     commitment transaction*. Since the other *peer* knows the
@@ -191,12 +191,12 @@ This is version 0.
     *hops*.
   * _See related: channel_
 
-* *Sending node*: 
+* *Sending node*:
    * A *node* that is sending a message.
    * _See category: node_
    * _See related: receiving node_
 
-* *Sending peer*: 
+* *Sending peer*:
    * A *node* that is sending a message to a directly connected *peer*.
    * _See category: peer_
    * _See related: receiving peer_.

--- a/00-introduction.md
+++ b/00-introduction.md
@@ -43,6 +43,7 @@ This is version 0.
    * A fast, off-chain method of mutual exchange between two *peers*.
    To transact funds, peers exchange signatures to create an updated *commitment transaction*.
    * _See closure methods: mutual close, revoked transaction close, unilateral close_
+   * _See related: route_
 
 * *Closing transaction*:
    * A transaction generated as part of a _mutual close_. A closing transaction is similar to a _commitment transaction_, but with no pending payments.
@@ -94,6 +95,11 @@ This is version 0.
     *commitment transaction*.
    * _See container: commitment transaction_
    * _See parts: Payment hash, Payment preimage_
+
+* *Invoice*: A request for funds on the Lightning Network, possibly
+    including payment type, payment amount, expiry, and other
+    information. This is how payments are made on the Lightning
+    Network, rather than using Bitcoin-style addresses.
 
 * *It's ok to be odd*:
    * A rule applied to some numeric fields that indicates either optional or
@@ -179,6 +185,11 @@ This is version 0.
     commitment transaction*. Since the other *peer* knows the
     *commitment revocation secret key*, it can create a *penalty transaction*.
    * _See related: mutual close, unilateral close_
+
+* *Route*: A path across the Lightning Network that enables a payment
+    from an *origin node* to a *final node* across one or more
+    *hops*.
+  * _See related: channel_
 
 * *Sending node*: 
    * A *node* that is sending a message.

--- a/00-introduction.md
+++ b/00-introduction.md
@@ -25,94 +25,11 @@ This is version 0.
 
 ## Glossary and Terminology Guide
 
-* *Node*:
-   * A computer or other device connected to the Bitcoin network.
-
-* *Peers*:
-   * *Nodes* transacting bitcoins with one another through a *channel*.
-
-* *MSAT*:
-   * A millisatoshi, often used as a field name.
-
-* *Funding transaction*:
-   * An irreversible on-chain transaction that pays to both *peers* on a *channel*.
-   It can only be spent by mutual consent.
-
-* *Channel*:
-   * A fast, off-chain method of mutual exchange between two *peers*.
-   To transact funds, peers exchange signatures to create an updated *commitment transaction*.
-
-* *Commitment transaction*:
-   * A transaction that spends the *funding transaction*.
-   Each *peer* holds the other peer's signature for this transaction, so that each
-   always has a commitment transaction that it can spend. After a new
-   commitment transaction is negotiated, the old one is *revoked*.
-
-* *HTLC*: Hashed Time Locked Contract.
-   * A conditional payment between two *peers*: the recipient can spend
-    the payment by presenting its signature and a *payment preimage*,
-    otherwise the payer can cancel the contract by spending it after
-    a given time. These are implemented as outputs from the
-    *commitment transaction*.
-
-* *Payment hash*:
-   * The *HTLC* contains the payment hash, which is the hash of the
-    *payment preimage*.
-
-* *Payment preimage*:
-   * Proof that payment has been received, held by
-    the final recipient, who is the only person who knows this
-    secret. The final recipient releases the preimage in order to
-    release funds. The payment preimage is hashed as the *payment hash*
-    in the *HTLC*.
-
-* *Commitment revocation secret key*:
-   * Every *commitment transaction* has a unique *commitment revocation* secret-key
-    value that allows the other *peer* to spend all outputs
-    immediately: revealing this key is how old commitment
-    transactions are revoked. To support revocation, each output of the
-    commitment transaction refers to the commitment revocation public key.
-
-* *Per-commitment secret*:
-   * Every *commitment transaction* derives its keys from a per-commitment secret,
-     which is generated such that the series of per-commitment secrets
-     for all previous commitments can be stored compactly.
-
-* *Mutual close*:
-   * A cooperative close of a *channel*, accomplished by broadcasting an unconditional
-    spend of the *funding transaction* with an output to each *peer*
-    (unless one output is too small, and thus is not included).
-
-* *Unilateral close*:
-   * An uncooperative close of a *channel*, accomplished by broadcasting a
-    *commitment transaction*. This transaction is larger (i.e. less
-    efficient) than a *mutual close* transaction, and the peer whose
-    commitment is broadcast cannot access its own outputs for some
-    previously-negotiated duration.
-
-* *Revoked transaction close*:
-   * An invalid close of a *channel*, accomplished by broadcasting a revoked
-    *commitment transaction*. Since the other *peer* knows the
-    *commitment revocation secret key*, it can create a *penalty transaction*.
-
-* *Penalty transaction*:
-   * A transaction that spends all outputs of a revoked *commitment
-    transaction*, using the *commitment revocation secret key*. A *peer* uses this
-    if the other peer tries to "cheat" by broadcasting a revoked
-    *commitment transaction*.
-
-* *Commitment number*:
-   * A 48-bit incrementing counter for each *commitment transaction*; counters
-    are independent for each *peer* in the *channel* and start at 0.
-
-* *It's ok to be odd*:
-   * A rule applied to some numeric fields that indicates either optional or
-     compulsory support for features. Even numbers indicate that both endpoints
-     MUST support the feature in question, while odd numbers indicate
-     that the feature MAY be disregarded by the other endpoint.
+* *Announcement*:
+   * A gossip message sent between *peers* intended to aid the discovery of a *channel* or a *node*.
 
 * `chain_hash`:
-   * Used in several of the BOLT documents to denote the genesis hash of a
+   * The genesis hash of a
      target blockchain. This allows *nodes* to create and reference *channels* on
      several blockchains. Nodes are to ignore any messages that reference a
      `chain_hash` that are unknown to them. Unlike `bitcoin-cli`, the hash is
@@ -121,6 +38,165 @@ This is version 0.
      For the main chain Bitcoin blockchain, the `chain_hash` value MUST be
      (encoded in hex):
      `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000`.
+
+* *Channel*:
+   * A fast, off-chain method of mutual exchange between two *peers*.
+   To transact funds, peers exchange signatures to create an updated *commitment transaction*.
+   * _See closure methods: mutal close, revoked transaction close, unilateral close_
+
+* *Closing transaction*:
+   * A transaction generated as part of a _mutual close_. A closing transaction is similar to a _commitment transaction_, but with no pending payments.
+   * _See related: commitment transaction, funding transaction, penalty transaction_
+
+* *Commitment number*:
+   * A 48-bit incrementing counter for each *commitment transaction*; counters
+    are independent for each *peer* in the *channel* and start at 0.
+   * _See container: commitment transaction_
+   * _See related: closing transaction, funding transaction, penalty transaction_
+
+* *Commitment revocation private key*:
+   * Every *commitment transaction* has a unique commitment revocation private-key
+    value that allows the other *peer* to spend all outputs
+    immediately: revealing this key is how old commitment
+    transactions are revoked. To support revocation, each output of the
+    commitment transaction refers to the commitment revocation public key.
+   * _See container: commitment transaction_
+   * _See originator: per-commitment secret_
+
+* *Commitment transaction*:
+   * A transaction that spends the *funding transaction*.
+   Each *peer* holds the other peer's signature for this transaction, so that each
+   always has a commitment transaction that it can spend. After a new
+   commitment transaction is negotiated, the old one is *revoked*.
+   * _See parts: commitment number, commitment revocation private key, HTLC, per-commitment secret_
+   * _See related: closing transaction, funding transaction, penalty transaction_
+   * _See types: revoked commitment transaction_
+
+* *Final node*:
+   * The final recipient of a packet that is routing a payment from an _origin node_ through some number of _hops_. It is also the final *receiving peer* in a chain.
+   * _See category: node_
+   * _See related: origin node, processing node_
+
+* *Funding transaction*:
+   * An irreversible on-chain transaction that pays to both *peers* on a *channel*.
+   It can only be spent by mutual consent.
+   * _See related: closing transaction, commitment transaction, penalty transaction_
+
+* *Hop*:
+   * A *node*. Generally, an intermmediate node lying between an *origin node* and a *final node*.
+   * _See category: node_
+
+* *HTLC*: Hashed Time Locked Contract.
+   * A conditional payment between two *peers*: the recipient can spend
+    the payment by presenting its signature and a *payment preimage*,
+    otherwise the payer can cancel the contract by spending it after
+    a given time. These are implemented as outputs from the
+    *commitment transaction*.
+   * _See container: commitment transaction_
+   * _See parts: Payment hash, Payment preimage_
+
+* *It's ok to be odd*:
+   * A rule applied to some numeric fields that indicates either optional or
+     compulsory support for features. Even numbers indicate that both endpoints
+     MUST support the feature in question, while odd numbers indicate
+     that the feature MAY be disregarded by the other endpoint.
+
+* *MSAT*:
+   * A millisatoshi, often used as a field name.
+
+* *Mutual close*:
+   * A cooperative close of a *channel*, accomplished by broadcasting an unconditional
+    spend of the *funding transaction* with an output to each *peer*
+    (unless one output is too small, and thus is not included).
+   * _See related: revoked transaction close, unilateral close__
+
+* *Node*:
+   * A computer or other device that is part of the Lightning network.
+   * _See related: peers_
+   * _See types: final node, hop, origin node, processing node, receiving node, sending node_
+
+* *Origin node*:
+   * The _node_ that originates a packet that will route a payment through some number of _hops_ to a _final node_. It is also the first _sending peer_ in a chain.
+   * _See category: node_
+   * _See related: final node, processing node_
+
+* *Payment hash*:
+   * The *HTLC* contains the payment hash, which is the hash of the
+    *payment preimage*.
+   * _See container: HTLC_
+   * _See originator: payment preimage_
+
+* *Payment preimage*:
+   * Proof that payment has been received, held by
+    the final recipient, who is the only person who knows this
+    secret. The final recipient releases the preimage in order to
+    release funds. The payment preimage is hashed as the *payment hash*
+    in the *HTLC*.
+   * _See container: HTLC_
+   * _See derivation: payment hash_
+
+* *Peers*:
+   * Two *nodes* that are in communication with each other.
+      * Two peers may gossip with each other prior to setting up a channel.
+      * Two peers may establish a *channel* through which they transact.
+   * _See related: node_
+
+* *Penalty transaction*:
+   * A transaction that spends all outputs of a *revoked commitment
+    transaction*, using the *commitment revocation private key*. A *peer* uses this
+    if the other peer tries to "cheat" by broadcasting a *revoked
+    commitment transaction*.
+   * _See related: closing transaction, commitment transaction, funding transaction_
+
+* *Per-commitment secret*:
+   * Every *commitment transaction* derives its keys from a per-commitment secret,
+     which is generated such that the series of per-commitment secrets
+     for all previous commitments can be stored compactly.
+   * _See container: commitment transaction_
+   * _See derivation: commitment revocation private key_
+
+* *Processing node*:
+   * A *node* that is processing a packet that originated with an *origin node* and that is being sent toward a *final node* in order to route a payment. It acts as a _receiving peer_ to receive the message, then a _sending peer_ to send on the packet.
+   * _See category: node_
+   * _See related: final node, origin node_
+
+* *Receiving node*:
+   * A *node* that is receiving a message.
+   * _See category: node_
+   * _See related: sending node_
+
+* *Receiving peer*:
+   * A *node* that is receiving a message from a directly connected *peer*.
+   * _See category: peer_
+   * _See related: sending peer_
+
+* *Revoked commitment transaction*:
+   * An old *commitment transaction* that has been revoked because a new commitment transaction has been negotiated.
+   * _See category: commitment transaction_
+   
+* *Revoked transaction close*:
+   * An invalid close of a *channel*, accomplished by broadcasting a *revoked
+    commitment transaction*. Since the other *peer* knows the
+    *commitment revocation secret key*, it can create a *penalty transaction*.
+   * _See related: mutal close, unilateral close_
+
+* *Sending node*: 
+   * A *node* that is sending a message.
+   * _See category: node_
+   * _See related: receiving node_
+
+* *Sending peer*: 
+   * A *node* that is sending a message to a directly connected *peer*.
+   * _See category: peer_
+   * _See related: receiving peer_.
+
+* *Unilateral close*:
+   * An uncooperative close of a *channel*, accomplished by broadcasting a
+    *commitment transaction*. This transaction is larger (i.e. less
+    efficient) than a *mutual close transaction*, and the *peer* whose
+    commitment is broadcast cannot access its own outputs for some
+    previously-negotiated duration.
+   * _See related: mutual close, revoked transaction close_
 
 ## Theme Song
 


### PR DESCRIPTION
Supersedes PR #384 since I couldn't push to @shannona's branch. Quoting from the original PR:

>This is a big change to the glossary in BOLT-0.
>
> The overarcing changes are:
>
> 1.) Reorganized glossary to be alphabetical
> 2.) Add copious "See also:" lines to cross-reference containers, contents, and other related entries.
> 
> Changed Definitions: Peer and node were revised based in on discussions with Rusty; commitment revocation secret key was changed to be commitment revocation private key based on #377.
>
> New Definitions: New words added based on their usage in the bolts were: announcement, closing transaction, final node, hop, origin node, processing, node, receiving node, receiving peer, revoked commitment transaction, sending node, sending peer.
>
> (I suspect the reorg will make the diffs almost useless, so this is the list of stuff to look at.)