### PR TITLE
BOLT4: `channel_update` is mandatory in `UPDATE` error messages

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -655,6 +655,8 @@ The top byte of `failure_code` can be read as a set of flags:
 * 0x2000 (NODE): node failure (otherwise channel)
 * 0x1000 (UPDATE): new channel update enclosed
 
+Please note that the `channel_update` field is mandatory in `UPDATE` messages.
+
 The following `failure_code`s are defined:
 
 1. type: PERM|1 (`invalid_realm`)

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -655,7 +655,8 @@ The top byte of `failure_code` can be read as a set of flags:
 * 0x2000 (NODE): node failure (otherwise channel)
 * 0x1000 (UPDATE): new channel update enclosed
 
-Please note that the `channel_update` field is mandatory in `UPDATE` messages.
+Please note that the `channel_update` field is mandatory in messages whose
+`failure_code` includes the `UPDATE` flag.
 
 The following `failure_code`s are defined:
 


### PR DESCRIPTION
We think that `mandatory` is more in line with the rest of the BOLT, but in any case the wording in the specs leaves room for interpretation (we believe it is mandatory and lnd for example believes it is optional) so it needs to be specified. 