### PR TITLE
BOLT 1: add testnet port

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -6,6 +6,7 @@ This protocol assumes an underlying authenticated and ordered transport mechanis
 [BOLT #8](08-transport.md) specifies the canonical transport layer used in Lightning, though it can be replaced by any transport that fulfills the above guarantees.
 
 The default TCP port is 9735. This corresponds to hexadecimal `0x2607`: the Unicode code point for LIGHTNING.<sup>[1](#reference-1)</sup>
+The default test network TCP port is 19735.
 
 All data fields are unsigned big-endian unless otherwise specified.
 


### PR DESCRIPTION
Running current lightning and test network lightning nodes on the same host is currently needlessly complicated because both nodes try to listen at the same port. Standardizing a port for testnet would also simplify communicating node information. 19735 doesn't seem to have relevant usage elsewhere.