### PR TITLE
use 'fail the channel' instead of 'reject the channel'

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -282,11 +282,11 @@ avoid double-spending of the funding transaction.
 
 The receiver:
   - if `minimum_depth` is unreasonably large:
-    - MAY reject the channel.
+    - MAY fail the channel.
   - if `channel_reserve_satoshis` is less than `dust_limit_satoshis` within the `open_channel` message:
-	- MUST reject the channel.
+	- MUST fail the channel.
   - if `channel_reserve_satoshis` from the `open_channel` message is less than `dust_limit_satoshis`:
-	- MUST reject the channel.
+	- MUST fail the channel.
 Other fields have the same requirements as their counterparts in `open_channel`.
 
 ### The `funding_created` Message


### PR DESCRIPTION
`reject the channel` only appears in "The accept_channel message" section. `fail the channel` in all others. Thought it is confusing to use different terms.