### PR TITLE
Modification of expressions mainly concerning ECDH function

### DIFF
--- a/08-transport.md
+++ b/08-transport.md
@@ -231,10 +231,10 @@ and 16 bytes for the `poly1305` tag.
 2. `h = SHA-256(h || e.pub.serializeCompressed())`
      * The newly generated ephemeral key is accumulated into the running
        handshake digest.
-3. `ss = ECDH(rs, e.priv)`
+3. `es = ECDH(rs, e.priv)`
      * The initiator performs an ECDH between its newly generated ephemeral
        key and the remote node's static public key.
-4. `ck, temp_k1 = HKDF(ck, ss)`
+4. `ck, temp_k1 = HKDF(ck, es)`
      * A new temporary encryption key is generated, which is
        used to generate the authenticating MAC.
 5. `c = encryptWithAD(temp_k1, 0, h, zero)`
@@ -258,10 +258,10 @@ and 16 bytes for the `poly1305` tag.
 4. `h = SHA-256(h || re.serializeCompressed())`
     * The responder accumulates the initiator's ephemeral key into the authenticating
       handshake digest.
-5. `ss = ECDH(re, s.priv)`
+5. `es = ECDH(re, s.priv)`
     * The responder performs an ECDH between its static private key and the
       initiator's ephemeral public key.
-6. `ck, temp_k1 = HKDF(ck, ss)`
+6. `ck, temp_k1 = HKDF(ck, es)`
     * A new temporary encryption key is generated, which will
       shortly be used to check the authenticating MAC.
 7. `p = decryptWithAD(temp_k1, 0, h, c)`
@@ -293,10 +293,10 @@ for the `poly1305` tag.
 2. `h = SHA-256(h || e.pub.serializeCompressed())`
      * The newly generated ephemeral key is accumulated into the running
        handshake digest.
-3. `ss = ECDH(re, e.priv)`
+3. `ee = ECDH(re, e.priv)`
      * where `re` is the ephemeral key of the initiator, which was received
        during Act One
-4. `ck, temp_k2 = HKDF(ck, ss)`
+4. `ck, temp_k2 = HKDF(ck, ee)`
      * A new temporary encryption key is generated, which is
        used to generate the authenticating MAC.
 5. `c = encryptWithAD(temp_k2, 0, h, zero)`
@@ -315,12 +315,12 @@ for the `poly1305` tag.
 3. If `v` is an unrecognized handshake version, then the responder MUST
     abort the connection attempt.
 4. `h = SHA-256(h || re.serializeCompressed())`
-5. `ss = ECDH(re, e.priv)`
+5. `ee = ECDH(re, e.priv)`
     * where `re` is the responder's ephemeral public key
     * The raw bytes of the remote party's ephemeral public key (`re`) are to be
       deserialized into a point on the curve using affine coordinates as encoded
       by the key's serialized composed format.
-6. `ck, temp_k2 = HKDF(ck, ss)`
+6. `ck, temp_k2 = HKDF(ck, ee)`
      * A new temporary encryption key is generated, which is
        used to generate the authenticating MAC.
 7. `p = decryptWithAD(temp_k2, 0, h, c)`
@@ -353,9 +353,9 @@ construction, and 16 bytes for a final authenticating tag.
 1. `c = encryptWithAD(temp_k2, 1, h, s.pub.serializeCompressed())`
     * where `s` is the static public key of the initiator
 2. `h = SHA-256(h || c)`
-3. `ss = ECDH(re, s.priv)`
+3. `se = ECDH(re, s.priv)`
     * where `re` is the ephemeral public key of the responder
-4. `ck, temp_k3 = HKDF(ck, ss)`
+4. `ck, temp_k3 = HKDF(ck, se)`
     * The final intermediate shared secret is mixed into the running chaining key.
 5. `t = encryptWithAD(temp_k3, 0, h, zero)`
      * where `zero` is a zero-length plaintext
@@ -383,9 +383,9 @@ construction, and 16 bytes for a final authenticating tag.
      * At this point, the responder has recovered the static public key of the
        initiator.
 5. `h = SHA-256(h || c)`
-6. `ss = ECDH(rs, e.priv)`
+6. `se = ECDH(rs, e.priv)`
      * where `e` is the responder's original ephemeral key
-7. `ck, temp_k3 = HKDF(ck, ss)`
+7. `ck, temp_k3 = HKDF(ck, se)`
 8. `p = decryptWithAD(temp_k3, 0, h, t)`
      * If the MAC check in this operation fails, then the responder MUST
        terminate the connection without any further messages.

--- a/08-transport.md
+++ b/08-transport.md
@@ -147,7 +147,7 @@ Throughout the handshake process, each side maintains these variables:
  * `e`: a party's **ephemeral keypair**. For each session, a node MUST generate a
    new ephemeral key with strong cryptographic randomness.
 
- * `s`: a party's **static public key** (`ls` for local, `rs` for remote)
+ * `s`: a party's **static keypair** (`ls` for local, `rs` for remote)
 
 The following functions will also be referenced:
 

--- a/08-transport.md
+++ b/08-transport.md
@@ -151,8 +151,8 @@ Throughout the handshake process, each side maintains these variables:
 
 The following functions will also be referenced:
 
-  * `ECDH(rk, k)`: performs an Elliptic-Curve Diffie-Hellman operation using
-    `rk`, which is a `secp256k1` public key, and `k`, which is a valid private key
+  * `ECDH(k, rk)`: performs an Elliptic-Curve Diffie-Hellman operation using
+    `k`, which is a valid private key, and `rk`, which is a `secp256k1` public key
     within the finite field, as defined by the curve parameters
       * The returned value is the SHA256 of the DER-compressed format of the
 	    generated point.
@@ -231,7 +231,7 @@ and 16 bytes for the `poly1305` tag.
 2. `h = SHA-256(h || e.pub.serializeCompressed())`
      * The newly generated ephemeral key is accumulated into the running
        handshake digest.
-3. `es = ECDH(rs, e.priv)`
+3. `es = ECDH(e.priv, rs)`
      * The initiator performs an ECDH between its newly generated ephemeral
        key and the remote node's static public key.
 4. `ck, temp_k1 = HKDF(ck, es)`
@@ -258,7 +258,7 @@ and 16 bytes for the `poly1305` tag.
 4. `h = SHA-256(h || re.serializeCompressed())`
     * The responder accumulates the initiator's ephemeral key into the authenticating
       handshake digest.
-5. `es = ECDH(re, s.priv)`
+5. `es = ECDH(s.priv, re)`
     * The responder performs an ECDH between its static private key and the
       initiator's ephemeral public key.
 6. `ck, temp_k1 = HKDF(ck, es)`
@@ -293,7 +293,7 @@ for the `poly1305` tag.
 2. `h = SHA-256(h || e.pub.serializeCompressed())`
      * The newly generated ephemeral key is accumulated into the running
        handshake digest.
-3. `ee = ECDH(re, e.priv)`
+3. `ee = ECDH(e.priv, re)`
      * where `re` is the ephemeral key of the initiator, which was received
        during Act One
 4. `ck, temp_k2 = HKDF(ck, ee)`
@@ -315,7 +315,7 @@ for the `poly1305` tag.
 3. If `v` is an unrecognized handshake version, then the responder MUST
     abort the connection attempt.
 4. `h = SHA-256(h || re.serializeCompressed())`
-5. `ee = ECDH(re, e.priv)`
+5. `ee = ECDH(e.priv, re)`
     * where `re` is the responder's ephemeral public key
     * The raw bytes of the remote party's ephemeral public key (`re`) are to be
       deserialized into a point on the curve using affine coordinates as encoded
@@ -353,7 +353,7 @@ construction, and 16 bytes for a final authenticating tag.
 1. `c = encryptWithAD(temp_k2, 1, h, s.pub.serializeCompressed())`
     * where `s` is the static public key of the initiator
 2. `h = SHA-256(h || c)`
-3. `se = ECDH(re, s.priv)`
+3. `se = ECDH(s.priv, re)`
     * where `re` is the ephemeral public key of the responder
 4. `ck, temp_k3 = HKDF(ck, se)`
     * The final intermediate shared secret is mixed into the running chaining key.
@@ -383,7 +383,7 @@ construction, and 16 bytes for a final authenticating tag.
      * At this point, the responder has recovered the static public key of the
        initiator.
 5. `h = SHA-256(h || c)`
-6. `se = ECDH(rs, e.priv)`
+6. `se = ECDH(e.priv, rs)`
      * where `e` is the responder's original ephemeral key
 7. `ck, temp_k3 = HKDF(ck, se)`
 8. `p = decryptWithAD(temp_k3, 0, h, t)`

--- a/08-transport.md
+++ b/08-transport.md
@@ -250,7 +250,7 @@ and 16 bytes for the `poly1305` tag.
 2. Parse the read message (`m`) into `v`, `re`, and `c`:
     * where `v` is the _first_ byte of `m`, `re` is the next 33
       bytes of `m`, and `c` is the last 16 bytes of `m`
-    * The raw bytes of the remote party's ephemeral public key (`e`) are to be
+    * The raw bytes of the remote party's ephemeral public key (`re`) are to be
       deserialized into a point on the curve using affine coordinates as encoded
       by the key's serialized composed format.
 3. If `v` is an unrecognized handshake version, then the responder MUST


### PR DESCRIPTION
BOLT 8: fix names of returned values of ECDH function 
ref. http://noiseprotocol.org/noise.html#overview-of-handshake-state-machine
Change `ss` to `es`, `ee`, `se` according to each case.
519517a

BOLT 8: change the order of arguments of ECDH function  
ref. http://noiseprotocol.org/noise.html#dh-functions
The order of arguments of DH function is the order of private key, public key.
Made the same order.
This order is reflected in the expressions of `ee`, `se`, `es`, `ss`.
f5ee583

BOLT 8: fix `s` description  
In this document `s` is not a public key but keypair.
Because there are expressions such as `s.priv`
86f4fde

BOLT 8: fix a typo
2ee4f2f