### PR TITLE
BOLT 1: Reply to unknown channels with an error

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -156,6 +156,7 @@ A sending node:
   - when sending `error`:
     - MUST fail the channel referred to by the error message.
   - SHOULD send `error` for protocol violations or internal errors that make channels unusable or that make further communication unusable.
+  - SHOULD send `error` in reply to messages of type `32`-`255` related to unknown channels.
   - MAY send an empty `data` field.
   - when failure was caused by an invalid signature check:
     - SHOULD include the raw, hex-encoded transaction in reply to a `funding_created`, `funding_signed`, `closing_signed`, or `commitment_signed` message.

--- a/01-messaging.md
+++ b/01-messaging.md
@@ -156,7 +156,7 @@ A sending node:
   - when sending `error`:
     - MUST fail the channel referred to by the error message.
   - SHOULD send `error` for protocol violations or internal errors that make channels unusable or that make further communication unusable.
-  - SHOULD send `error` in reply to messages of type `32`-`255` related to unknown channels.
+  - SHOULD send `error` with the unknown `channel_id` in reply to messages of type `32`-`255` related to unknown channels.
   - MAY send an empty `data` field.
   - when failure was caused by an invalid signature check:
     - SHOULD include the raw, hex-encoded transaction in reply to a `funding_created`, `funding_signed`, `closing_signed`, or `commitment_signed` message.


### PR DESCRIPTION
It seems like a reasonable thing to do but the spec isn't currently clear on that, leading to differences between implementations.

See https://github.com/lightningnetwork/lnd/issues/1882.