### PR TITLE
Make unit explicit encoded in BOLT11 invoice

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -43,7 +43,7 @@ and MUST fail if the checksum is incorrect.
 The human-readable part of a Lightning invoice consists of two sections:
 1. `prefix`: `ln` + BIP-0173 currency prefix (e.g. `lnbc` for bitcoin mainnet, `lntb` for bitcoin testnet and `lnbcrt` for bitcoin regtest)
 1. `amount`: optional number in that currency, followed by an optional
-   `multiplier` letter
+   `multiplier` letter. The unit encoded here is the 'social' convention of a payment unit -- in the case of Bitcoin the unit is 'bitcoin' NOT satoshis.
 
 The following `multiplier` letters are defined:
 


### PR DESCRIPTION
I keep forgetting what the base currency unit is in BOLT11, so make it explicit. 