### PR TITLE
gossip: clarify what it means to 'discard a channel'

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -480,7 +480,7 @@ The final node:
   - otherwise:
     - if `htlc_maximum_msat` is not present or greater than channel capacity:
 	  - MAY blacklist this `node_id`
-	  - SHOULD discard this channel.
+	  - SHOULD ignore this channel during route considerations.
 	- otherwise:
 	  - SHOULD consider the `htlc_maximum_msat` when routing.
 


### PR DESCRIPTION
It's unclear what it means to `discard` a channel. Instead,
let's use the common phrase to `fail` a channel.

I'm assuming that `fail` is the same as `discard` here, but maybe it's meant to say discard the `message`? (But that seems unlikely, given the context).