### PR TITLE
BOLT #2: order htlc_signatures by BIP69 + increasing CLTV.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -950,7 +950,7 @@ change the commitment transaction aside from the new revocation number
 (due to dust, identical HTLC replacement, or insignificant or multiple
 fee changes).
   - MUST include one `htlc_signature` for every HTLC transaction corresponding
-  to BIP69 lexicographic ordering of the commitment transaction.
+    to BIP69+CLTV lexicographic ordering of the commitment transaction.
   - if it has not recently received a message from the remote node:
       - SHOULD use `ping` and await the reply `pong` before sending `commitment_signed`.
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -950,7 +950,7 @@ change the commitment transaction aside from the new revocation number
 (due to dust, identical HTLC replacement, or insignificant or multiple
 fee changes).
   - MUST include one `htlc_signature` for every HTLC transaction corresponding
-    to BIP69+CLTV lexicographic ordering of the commitment transaction.
+    to the ordering of the commitment transaction (see [BOLT #3](03-transactions.md#transaction-input-and-output-ordering)).
   - if it has not recently received a message from the remote node:
       - SHOULD use `ping` and await the reply `pong` before sending `commitment_signed`.
 

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -42,7 +42,15 @@ This details the exact format of on-chain transactions, which both sides need to
 
 ## Transaction Input and Output Ordering
 
-Lexicographic ordering: see [BIP69](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki).
+Lexicographic ordering: see [BIP69](https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki).  In the case of identical HTLC outputs, the outputs are ordered in increasing `cltv_expiry` order.
+
+## Rationale
+
+Two offered HTLCs which have the same `amount_msat` and `payment_hash`
+will have identical outputs, even if their `cltv_expiry` differs.
+This only matters because the same ordering is used to send
+`htlc_signatures` and the HTLC transactions themselves are different,
+thus the two peers must agree on the canonical ordering for this case.
 
 ## Use of Segwit
 
@@ -398,7 +406,7 @@ committed HTLCs:
    add a [`to_local` output](#to_local-output).
 6. If the `to_remote` amount is greater or equal to `dust_limit_satoshis`,
    add a [`to_remote` output](#to_remote-output).
-7. Sort the outputs into [BIP 69 order](#transaction-input-and-output-ordering).
+7. Sort the outputs into [BIP 69+CLTV order](#transaction-input-and-output-ordering).
 
 # Keys
 


### PR DESCRIPTION
We express it has how the outputs are ordered, but the only way you can
detect that is by the htlc_signatures order, which is the part which really
matters.

I finally reproduced this, BTW, which is why I'm digging it up!

Closes: #448
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>