### PR TITLE
Clarify temporary_channel_id's acceptable usages

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -328,3 +328,5 @@ regtest
 ratelimiting
 zlib
 ZLIB
+APIs
+duplicative

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -251,7 +251,7 @@ identifier for a channel before funding_created has been exchanged is the
 (source_node_id, destination_node_id, temporary_channel_id) tuple. Note that
 any such APIs which reference channels by their channel id before the funding
 transaction is confirmed are also not persistent - until you know the script
-pubkey corresponding to the funding txo nothing prevents duplicative channel
+pubkey corresponding to the funding output nothing prevents duplicative channel
 ids.
 
 #### Future

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -110,7 +110,7 @@ The existence of the `chain_hash` allows nodes to open channels
 across many distinct blockchains as well as have channels within multiple
 blockchains opened to the same peer (if it supports the target chains).
 
-The `temporary_channel_id` is used to identify this channel until the
+The `temporary_channel_id` is used to identify this channel on a per-peer basis until the
 funding transaction is established, at which point it is replaced
 by the `channel_id`, which is derived from the funding transaction.
 
@@ -241,6 +241,18 @@ would be eliminated as dust.  The similar requirements in
 are above both `dust_limit_satoshis`.
 
 Details for how to handle a channel failure can be found in [BOLT 5:Failing a Channel](05-onchain.md#failing-a-channel).
+
+#### Practical Considerations for temporary_channel_id
+
+Note that as duplicate `temporary_channel_id`s may exist from different
+peers, APIs which reference channels by their channel id before the funding
+transaction is created are inherently unsafe. The only protocol-provided
+identifier for a channel before funding_created has been exchanged is the
+(source_node_id, destination_node_id, temporary_channel_id) tuple. Note that
+any such APIs which reference channels by their channel id before the funding
+transaction is confirmed are also not persistent - until you know the script
+pubkey corresponding to the funding txo nothing prevents duplicative channel
+ids.
 
 #### Future
 


### PR DESCRIPTION
Because apparently we're dead-set on making sure that the obvious way to implement the spec is incorrect (and will lead to bugs downstream of implementors, see #475), we need to be extra-doubly-sure that we spell this out. Note that based on their wiki at least @acinq (@pm47 @sstone) have a bug here, and the lnd/c-lightning docs need to clarify this as they appear to indicate to users they can do this.