### PR TITLE
BOLT 3 : Fix ambiguity on HTLC transactions spendable by a penalty one

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -217,7 +217,7 @@ less than `dust_limit_satoshis` set by the transaction owner:
 
 ## HTLC-Timeout and HTLC-Success Transactions
 
-These HTLC transactions are almost identical, except the HTLC-timeout transaction is timelocked. The HTLC-timeout transaction is also the transaction that can be spent by a valid penalty transaction.
+These HTLC transactions are almost identical, except the HTLC-timeout transaction is timelocked. Both HTLC-timeout/HTLC-success transactions can be spent by a valid penalty transaction.
 
 * version: 2
 * locktime: `0` for HTLC-success, `cltv_expiry` for HTLC-timeout


### PR DESCRIPTION
Both HTLC-success/HTLC-timeout can be spent by a valid penalty
transaction

Both HTLC type of tx can be spent by a remote peer in knowledge of local per_commitment_secret. Does it is something out of date or I'm missing something ?