### PR TITLE
04-onion-routing: document non-strict forwarding

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -198,8 +198,8 @@ ill-crafted HTLC.
 
 Field descriptions:
 
-   * `short_channel_id`: The ID of the channel used to route the message;
-     the receiving peer is the other end of the channel.
+   * `short_channel_id`: The ID of the outgoing channel used to route the 
+      message; the receiving peer should operate the other end of this channel.
 
    * `amt_to_forward`: The amount, in millisatoshis, to forward to the next
      receiving peer specified within the routing information.
@@ -238,6 +238,49 @@ Field descriptions:
 When forwarding HTLCs, nodes MUST construct the outgoing HTLC as specified within
 `per_hop` above; otherwise, deviation from the specified HTLC parameters
 may lead to extraneous routing failure.
+
+## Non-strict Forwarding
+
+A node MAY forward an HTLC along an outgoing channel other than the one
+specified by `short_channel_id`, so long as the receiver has the same node
+public key intended by `short_channel_id`. Thus, if `short_channel_id` connects
+nodes A and B, the HTLC can forwarded across any channel connecting A and B.
+Failure to adhere will result in the receiver being unable to decrypt the next
+hop in the onion packet.
+
+### Rationale
+
+In the event that two peers have multiple channels, the downstream node will be
+able to decrypt the next hop payload regardless of which channel the packet is
+sent across.
+
+Nodes implementing non-strict forwarding are able to make real-time assessments
+of channel bandwidths with a particular peer, and use the channel that is
+locally-optimal. 
+
+For example, if the channel specified by `short_channel_id` connecting A and B
+does not have enough bandwidth at forwarding time, then A is able use a
+different channel that does. This can reduce payment latency by preventing the
+HTLC from failing due to bandwidth constraints across `short_channel_id`, only
+to have the sender attempt the same route differing only in the channel between
+A and B.
+
+Non-strict forwarding allows nodes to make use of private channels connecting
+them to the receiving node, even if the channel is not known in the public
+channel graph.
+
+### Recommendation
+
+Implementations using non-strict forwarding should consider applying the same
+fee schedule to all channels with the same peer, as senders are likely to select
+the channel which results in the lowest overall cost. Having distinct policies
+may result in the forwarding node accepting fees based on the most optimal fee
+schedule for the sender, even though they are providing aggregate bandwidth
+across all channels with the same peer.
+
+Alternatively, implementations may choose to apply non-strict forwarding only to
+like-policy channels to ensure their expected fee revenue does not deviate by
+using an alternate channel.
 
 ## Payload for the Last Node
 


### PR DESCRIPTION
This PR documents the allowance of non-strict
forwarding, permitting forwarding nodes to select
between any available outgoing channel with the peer
that would otherwise be specified by the
short_channel_id in the onion packet.

It also includes recommendations for fee schedules
when using non-strict forwarding, either by using
a uniform fee schedule with a peer or only
considering like-policied channels, to ensure the
channel is truly equivalent in terms of fee revenue
for the forwarder.