### PR TITLE
BOLT 2: `Hashed Time Locked Contracts` not `Hash TimeLocked Contracts`.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -549,7 +549,7 @@ reason to pay a premium for rapid processing.
 
 ## Normal Operation
 
-Once both nodes have exchanged `funding_locked` (and optionally [`announcement_signatures`](07-routing-gossip.md#the-announcement_signatures-message)), the channel can be used to make payments via Hash TimeLocked Contracts.
+Once both nodes have exchanged `funding_locked` (and optionally [`announcement_signatures`](07-routing-gossip.md#the-announcement_signatures-message)), the channel can be used to make payments via Hashed Time Locked Contracts.
 
 Changes are sent in batches: one or more `update_` messages are sent before a
 `commitment_signed` message, as in the following diagram:


### PR DESCRIPTION
Be consistent.
ref. 00-introduction.md#glossary-and-terminology-guide