### PR TITLE
BOLT 0,2,5: `closing transaction` not `(mutual) close transaction`.

### DIFF
--- a/00-introduction.md
+++ b/00-introduction.md
@@ -267,7 +267,7 @@ See [BOLT #11: Invoice Protocol for Lightning Payments](11-payment-encoding.md) 
 * *Unilateral close*:
    * An uncooperative close of a *channel*, accomplished by broadcasting a
     *commitment transaction*. This transaction is larger (i.e. less
-    efficient) than a *mutual close transaction*, and the *peer* whose
+    efficient) than a *closing transaction*, and the *peer* whose
     commitment is broadcast cannot access its own outputs for some
     previously-negotiated duration.
    * _See related: mutual close, revoked transaction close_

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -493,7 +493,7 @@ The `shutdown` response requirement implies that the node sends `commitment_sign
 Once shutdown is complete and the channel is empty of HTLCs, the final
 current commitment transactions will have no HTLCs, and closing fee
 negotiation begins.  The funder chooses a fee it thinks is fair, and
-signs the close transaction with the `scriptpubkey` fields from the
+signs the closing transaction with the `scriptpubkey` fields from the
 `shutdown` messages (along with its chosen fee) and sends the signature;
 the other node then replies similarly, using a fee it thinks is fair.  This
 exchange continues until both agree on the same fee or when one side fails
@@ -520,7 +520,7 @@ The sending node:
  transaction, as specified in [BOLT #3](03-transactions.md#closing-transaction).
 
 The receiving node:
-  - if the `signature` is not valid for either variant of close transaction
+  - if the `signature` is not valid for either variant of closing transaction
   specified in [BOLT #3](03-transactions.md#closing-transaction):
     - MUST fail the connection.
   - if `fee_satoshis` is equal to its previously sent `fee_satoshis`:

--- a/05-onchain.md
+++ b/05-onchain.md
@@ -160,7 +160,7 @@ it to be processed.
 
 # Mutual Close Handling
 
-A mutual close transaction *resolves* the funding transaction output.
+A closing transaction *resolves* the funding transaction output.
 
 In the case of a mutual close, a node need not do anything else, as it has
 already agreed to the output, which is sent to its specified `scriptpubkey` (see


### PR DESCRIPTION
Be consistent.