### PR TITLE
BOLT 7: add extended channel queries

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -331,3 +331,4 @@ zlib
 ZLIB
 APIs
 duplicative
+CRC

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -260,6 +260,7 @@ aa
 df
 versa
 timestamp
+timestamps
 metadata
 Bitcoin's
 Versioning

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -865,9 +865,10 @@ Channel digest information for each channel is encoded as follow:
 - `short_channel_id`
 - timestamp of the `channel_update` for node 1
 - timestamp of the `channel_update` for node 2
-- 4 bytes CRC32 checksum of the following fields: `short_channel_id`, `message_flags`, `channel_flags`, `cltv_expiry_delta`,
- `htlc_minimum_msat`, `fee_base_msat`, `fee_proportional_millionths`, `htlc_maximum_msat`
+- checksum for the `channel_update` for node 1
+- checksum for the `channel_update` for node 2
 
+The checksum for a `channel_update` is a CRC32 checksum that covers the following fields: `short_channel_id`, `channel_flags`, `cltv_expiry_delta`, `fee_base_msat`, `fee_proportional_millionths`. It can be used to avoid querying new updates that do not include new information, and does not cover static fields such as `htlc_minimum_msat` or `htlc_maximum_msat`.
 
 #### Rationale
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -157,7 +157,7 @@ The origin node:
   - MUST set `chain_hash` to the 32-byte hash that uniquely identifies the chain
   that the channel was opened within:
     - for the _Bitcoin blockchain_:
-      - MUST set `chain_hash` value (encoded in hex) equal to `6Feb28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000`.
+      - MUST set `chain_hash` value (encoded in hex) equal to `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000`.
   - MUST set `short_channel_id` to refer to the confirmed funding transaction,
   as specified in [BOLT #2](02-peer-protocol.md#the-funding_locked-message).
     - Note: the corresponding output MUST be a P2WSH, as described in [BOLT #3](03-transactions.md#funding-transaction-output).

--- a/09-features.md
+++ b/09-features.md
@@ -26,6 +26,7 @@ These flags may only be used in the `init` message:
 | 3  | `initial_routing_sync` | Indicates that the sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 | 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 | 6/7  | `gossip_queries`           | More sophisticated gossip control | [BOLT #7](07-routing-gossip.md#query-messages) |
+| 16/17  | `extended_gossip_queries`           | Gossip queries with extra timestamps | [BOLT #7](07-routing-gossip.md#extended-query-messages) |
 
 ## Assigned `globalfeatures` flags
 


### PR DESCRIPTION
Extended channel queries include extra timestamps (one for each channel_update), which
allows nodes that are often online to easily sync their routing tables.