### PR TITLE
fix a requirement mistake of `next_remote_revocation_number`.

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1165,6 +1165,9 @@ A node:
   commitment number of the last `commitment_signed` message the receiving
   node has sent:
       - SHOULD fail the channel.
+    - if it has not sent `commitment_signed`, AND `next_local_commitment_number`
+    is not equal to 1:
+      - SHOULD fail the channel.
   - if `next_remote_revocation_number` is equal to the commitment number of
   the last `revoke_and_ack` the receiving node sent, AND the receiving node
   hasn't already received a `closing_signed`:

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1174,7 +1174,7 @@ A node:
     commitment number of the last `revoke_and_ack` the receiving node has sent:
       - SHOULD fail the channel.
     - if it has not sent `revoke_and_ack`, AND `next_remote_revocation_number`
-    is equal to 0:
+    is not equal to 0:
       - SHOULD fail the channel.
 
  A receiving node:


### PR DESCRIPTION
And added an equivalent requirement for `next_local_commitment_number`.