### PR TITLE
BOLT 7: fix hashed data range in the `node_announcement`.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -316,7 +316,7 @@ The receiving node:
     - MUST NOT process the message further.
   - if `signature` is NOT a valid signature (using `node_id` of the
   double-SHA256 of the entire message following the `signature` field, including
-  unknown fields following `alias`):
+any future fields appended to the end):
     - SHOULD fail the connection.
     - MUST NOT process the message further.
   - if `features` field contains _unknown even bits_:


### PR DESCRIPTION
currently the `alias` is not the last field.