### PR TITLE
BOLT 4: include `channel_update`'s message type

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -704,7 +704,7 @@ The top byte of `failure_code` can be read as a set of flags:
 * 0x1000 (UPDATE): new channel update enclosed
 
 Please note that the `channel_update` field is mandatory in messages whose
-`failure_code` includes the `UPDATE` flag.
+`failure_code` includes the `UPDATE` flag, and that when enclosed the `channel_update` must include the wire message type.
 
 The following `failure_code`s are defined:
 


### PR DESCRIPTION
Some failure messages include a `channel_update`, and it is currently not clear if, when included, the `channel_update` must be written with or without its wire message type (258).

As a result, initially both c-lightning and eclair were including it, and lnd didn't, but then c-lightning removed it thinking they were the only one including the type. So currently c-lightning and lnd are ommitting the type, eclair include it. I wonder what ptarmigan does? @nayuta-gondo @nayuta-ueno 

Since there are always been disagreements, we have all implemented a compatibility mode to be able to *read* the update with or without the type, but we still *write* it differently 🙃. That definitely requires clarification, in one way or another.


