### PR TITLE
option_data_loss_protect: concretely define `my_current_per_commitment_point`

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1167,6 +1167,9 @@ The sending node:
   - MUST set `next_revocation_number` to the commitment number of the
   next `revoke_and_ack` message it expects to receive.
   - if it supports `option_data_loss_protect`:
+    - MUST set `my_current_per_commitment_point` to its commitment point for
+      the last signed commitment it received from its channel peer (i.e. the commitment_point 
+      corresponding to the commitment transaction the sender would use to unilaterally close).
     - if `next_revocation_number` equals 0:
       - MUST set `your_last_per_commitment_secret` to all zeroes
     - otherwise:


### PR DESCRIPTION
Make it more obvious what the expected value of `my_current_per_commitment_point` is.