### PR TITLE
BOLT 4: Clarify final_incorrect_cltv_expiry data

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -824,7 +824,7 @@ handling by the final node.
 
 1. type: 18 (`final_incorrect_cltv_expiry`)
 2. data:
-   * [`4`:`cltv_expiry`]
+   * [`4`:`incoming_cltv_expiry`]
 
 The CLTV expiry in the HTLC doesn't match the value in the onion.
 


### PR DESCRIPTION
use `update_add_htlc.cltv_expiry` like `final_incorrect_htlc_amount`.