### PR TITLE
BOLT7: extend channel range queries with optional fields

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -3,6 +3,8 @@ bitfields
 checksums
 timestamps
 tlv
+tlvs
+subtype
 TLV
 py
 vsprintf

--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -1,4 +1,9 @@
 personal_ws-1.1 en 264
+bitfields
+checksums
+timestamps
+tlv
+TLV
 py
 vsprintf
 glibc
@@ -336,6 +341,7 @@ zlib
 ZLIB
 APIs
 duplicative
+CRC
 DoS
 ECDSA
 TLV

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -666,6 +666,10 @@ The receiver:
         - MUST reply with the latest `channel_update` for `node_id_1`
       - if bit 2 of `query_flag` is set and it has received a `channel_update` from `node_id_2`:
         - MUST reply with the latest `channel_update` for `node_id_2`
+      - if bit 3 of `query_flag` is set and it has received a `node_announcement` from `node_id_1`:
+        - MUST reply with the latest `node_announcement` for `node_id_1`
+      - if bit 4 of `query_flag` is set and it has received a `node_announcement` from `node_id_2`:
+        - MUST reply with the latest `node_announcement` for `node_id_2`
 	- SHOULD NOT wait for the next outgoing gossip flush to send these.
   - MUST follow with any `node_announcement`s for each `channel_announcement`
 	- SHOULD avoid sending duplicate `node_announcements` in response to a single `query_short_channel_ids`.
@@ -699,7 +703,7 @@ timeouts.  It also causes a natural ratelimiting of queries.
 2. types:
     1. type: 1 (`query_option`)
     2. data:
-        * [`1`:`query_option_flags`]
+        * [`varint`:`query_option_flags`]
 
 `query_option_flags` is a bitfield represented as a minimally-encoded varint. Bits have the following meaning:
 
@@ -784,8 +788,8 @@ The receiver of `query_channel_range`:
       - SHOULD set `complete` to 1.
 
 If the incoming message includes `query_option`, the receiver MAY append additional information to its reply:
-- if bit 0 in `query_option_flags` is set, the receive MAY append a `timestamps_tlv` that contains `channel_update` timestamps for all `short_chanel_id`s in `encoded_short_ids`
-- if bit 1 in `query_option_flags` is set, the receive MAY append a `checksums_tlv` that contains `channel_update` checksums for all `short_chanel_id`s in `encoded_short_ids`
+- if bit 0 in `query_option_flags` is set, the receiver MAY append a `timestamps_tlv` that contains `channel_update` timestamps for all `short_chanel_id`s in `encoded_short_ids`
+- if bit 1 in `query_option_flags` is set, the receiver MAY append a `checksums_tlv` that contains `channel_update` checksums for all `short_chanel_id`s in `encoded_short_ids`
 
 
 #### Rationale

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -587,6 +587,8 @@ Query messages can be extended with optional fields that can help reduce the num
 - timestamp-based filtering of `channel_update` messages: only ask for `channel_update` messages that are newer than the ones you already have.
 - checksum-based filtering of `channel_update` messages: only ask for `channel_update` messages that carry different information from the ones you already have.
 
+Nodes can signal that they support extended gossip queries with the `gossip_queries_ex` feature bit.
+
 ### The `query_short_channel_ids`/`reply_short_channel_ids_end` Messages
 
 1. type: 261 (`query_short_channel_ids`) (`gossip_queries`)

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -580,6 +580,11 @@ are unique 8-byte values, no more than 14 bytes can be duplicated
 across the stream: as each duplicate takes at least 2 bits, no valid
 contents could decompress to more then 3669960 bytes.
 
+Query messages can be extended with optional fields that can help reduce the number of messages needed to synchronize routing tables by enabling:
+
+- timestamp-based filtering of `channel_update` messages: only ask for `channel_update` messages that are newer than the ones you already have.
+- checksum-based filtering of `channel_update` messages: only ask for `channel_update` messages that carry different information from the ones you already have.
+
 ### The `query_short_channel_ids`/`reply_short_channel_ids_end` Messages
 
 1. type: 261 (`query_short_channel_ids`) (`gossip_queries`)
@@ -687,6 +692,19 @@ timeouts.  It also causes a natural ratelimiting of queries.
     * [`chain_hash`:`chain_hash`]
     * [`u32`:`first_blocknum`]
     * [`u32`:`number_of_blocks`]
+    * [`query_channel_range_tlv`]
+      * type: 1 (`query_option`)
+      * data:
+        * [`1`:`query_option_flags`]
+
+`query_option_flags` is a bitfield represented as a minimally-encoded varint. Bits have the following meaning:
+
+| Bit Position  | Meaning                 |
+| ------------- | ----------------------- |
+| 0             | Sender wants timestamps |
+| 1             | Sender wants checksums  |
+
+Though it is possible, it would not be very useful to ask for checksums without asking for timestamps too: the receiving node may have an older `channel_update` with a different checksum, asking for it would be useless. And if a `channel_update` checksum is actually 0 (which is quite unlikely) it will not be queried.
 
 1. type: 264 (`reply_channel_range`) (`gossip_queries`)
 2. data:
@@ -696,8 +714,36 @@ timeouts.  It also causes a natural ratelimiting of queries.
     * [`byte`:`complete`]
     * [`u16`:`len`]
     * [`len*byte`:`encoded_short_ids`]
+    * [`reply_channel_range_tlv`]
+      * type: 1 (`timestamps_tlv`)
+      * data:
+        * [`1`:`encoding_type`]
+        * [`timestamps_tlv_len-1`:`encoded_timestamps`]
+      * type: 3 (`checksums_tlv`)
+      * data:
+        * [`checksums_tlv_len`:`encoded_checksums`]
 
-This allows a query for channels within specific blocks.
+For a single `channel_update`, timestamps are encoded as:
+
+* [`4`:`timestamp_node_id_1`]
+* [`4`:`timestamp_node_id_2`]
+
+Where:
+* `timestamp_node_id_1` is the timestamp of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
+* `timestamp_node_id_2` is the timestamp of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
+
+For a single `channel_update`, checksums are encoded as:
+
+* [`4`:`checksum_node_id_1`]
+* [`4`:`checksum_node_id_2`]
+
+Where:
+* `checksum_node_id_1` is the checksum of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
+* `checksum_node_id_2` is the checksum of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
+
+The checksum of a `channel_update` is the CRC32 checksum of this `channel_update` without its `signature` and `timestamp` fields.
+
+This allows to query for channels within specific blocks.
 
 #### Requirements
 
@@ -707,6 +753,7 @@ The sender of `query_channel_range`:
   that it wants the `reply_channel_range` to refer to
   - MUST set `first_blocknum` to the first block it wants to know channels for
   - MUST set `number_of_blocks` to 1 or greater.
+  - MAY append an additional `query_channel_range_tlv`, which specifies the type of extended information it would like to receive.  
 
 The receiver of `query_channel_range`:
   - if it has not sent all `reply_channel_range` to a previously received `query_channel_range` from this sender:
@@ -724,11 +771,18 @@ The receiver of `query_channel_range`:
     - otherwise:
       - SHOULD set `complete` to 1.
 
+If the incoming message includes a `query_channel_range_tlv` that it understands, the receiver MAY append additional information to its reply.
+- if bit 0 in `query_option_flags` is set, the receive MAY append a `timestamps_tlv` that contains `channel_update` timestamps for all `short_chanel_id`s in `encoded_short_ids`
+- if bit 1 in `query_option_flags` is set, the receive MAY append a `checksums_tlv` that contains `channel_update` checksums for all `short_chanel_id`s in `encoded_short_ids`
+
+
 #### Rationale
 
 A single response might be too large for a single packet, and also a peer can
 store canned results for (say) 1000-block ranges, and simply offer each reply
 which overlaps the ranges of the request.
+
+The addition of timestamp and checksum fields allow a peer to omit querying for redundant updates.
 
 ### The `gossip_timestamp_filter` Message
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -574,6 +574,8 @@ Encoding types:
 * `0`: uncompressed array of `short_channel_id` types, in ascending order.
 * `1`: array of `short_channel_id` types, in ascending order, compressed with zlib deflate<sup>[1](#reference-1)</sup>
 
+This encoding is also used for arrays of other types (timestamps, flags, ...), and specified with an `encoded_` prefix. For example, `encoded_timestamps` is an array of timestamps than can be either compressed (with a `1` prefix) or uncompressed (with a `0` prefix).
+
 Note that a 65535-byte zlib message can decompress into 67632120
 bytes<sup>[2](#reference-2)</sup>, but since the only valid contents
 are unique 8-byte values, no more than 14 bytes can be duplicated
@@ -592,14 +594,13 @@ Query messages can be extended with optional fields that can help reduce the num
     * [`chain_hash`:`chain_hash`]
     * [`u16`:`len`]
     * [`len*byte`:`encoded_short_ids`]
-    * [`tlvs`:`query_short_channel_ids_tlvs`]
+    * [`query_short_channel_ids_tlvs`:`tlvs`]
 
-1. tlvs: `query_short_channel_ids_tlv`
+1. tlvs: `query_short_channel_ids_tlvs`
 2. types:
     1. type: 1 (`query_flags`)
     2. data:
-        * [`byte`:`encoding_type`]
-        * [`len-1`:`encoded_query_flags`]
+        * [`...*byte`:`encoded_query_flags`]
 
 `encoded_query_flags` is an array of bitfields, one varint per bitfield, one bitfield for each `short_channel_id`. Bits have the following meaning:
 
@@ -697,7 +698,7 @@ timeouts.  It also causes a natural ratelimiting of queries.
     * [`chain_hash`:`chain_hash`]
     * [`u32`:`first_blocknum`]
     * [`u32`:`number_of_blocks`]
-    * [`tlvs`:`query_channel_range_tlvs`]
+    * [`query_channel_range_tlvs`:`tlvs`]
 
 1. tlvs: `query_channel_range_tlvs`
 2. types:
@@ -722,18 +723,16 @@ Though it is possible, it would not be very useful to ask for checksums without 
     * [`byte`:`complete`]
     * [`u16`:`len`]
     * [`len*byte`:`encoded_short_ids`]
-    * [`tlvs`:`reply_channel_range_tlvs`]
+    * [`reply_channel_range_tlvs`:`tlvs`]
 
 1. tlvs: `query_channel_range_tlvs`
 2. types:
     1. type: 1 (`timestamps_tlv`)
     2. data:
-        * [`byte`:`encoding_type`]
-        * [`len-1`:`encoded_timestamps`]
+        * [`...*byte`:`encoded_timestamps`]
     1. type: 3 (`checksums_tlv`)
     2. data:
-        * [`byte`:`encoding_type`]
-        * [`len-1`:`encoded_checksums`]
+        * [`...*byte`:`checksums`]
 
 For a single `channel_update`, timestamps are encoded as:
 
@@ -759,7 +758,7 @@ Where:
 
 The checksum of a `channel_update` is the CRC32C checksum as specified in [RFC3720](https://tools.ietf.org/html/rfc3720#appendix-B.4) of this `channel_update` without its `signature` and `timestamp` fields.
 
-This allows to query for channels within specific blocks.
+This allows to query for channels within specific blocks. 
 
 #### Requirements
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -728,7 +728,8 @@ Though it is possible, it would not be very useful to ask for checksums without 
         * [`len-1`:`encoded_timestamps`]
     1. type: 3 (`checksums_tlv`)
     2. data:
-        * [`len`:`encoded_checksums`]
+        * [`byte`:`encoding_type`]
+        * [`len-1`:`encoded_checksums`]
 
 For a single `channel_update`, timestamps are encoded as:
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -659,6 +659,7 @@ The receiver:
   - MUST respond to each known `short_channel_id`:
     - if the incoming message does not include `encoded_query_flags`:
       - with a `channel_announcement` and the latest `channel_update` for each end
+      - MUST follow with any `node_announcement`s for each `channel_announcement`
     - otherwise:
       - We define `query_flag` for the Nth `short_channel_id` in
         `encoded_short_ids` to be the Nth varint of the decoded
@@ -674,8 +675,7 @@ The receiver:
       - if bit 4 of `query_flag` is set and it has received a `node_announcement` from `node_id_2`:
         - MUST reply with the latest `node_announcement` for `node_id_2`
 	- SHOULD NOT wait for the next outgoing gossip flush to send these.
-  - MUST follow with any `node_announcement`s for each `channel_announcement`
-	- SHOULD avoid sending duplicate `node_announcements` in response to a single `query_short_channel_ids`.
+  - SHOULD avoid sending duplicate `node_announcements` in response to a single `query_short_channel_ids`.
   - MUST follow these responses with `reply_short_channel_ids_end`.
   - if does not maintain up-to-date channel information for `chain_hash`:
 	- MUST set `complete` to 0.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -592,13 +592,14 @@ Query messages can be extended with optional fields that can help reduce the num
     * [`chain_hash`:`chain_hash`]
     * [`u16`:`len`]
     * [`len*byte`:`encoded_short_ids`]
-    * [`query_short_channel_ids_tlv`]
-      * type: 1 (`query_flags`)
-      * data:
-        * [`1`:`encoding_type`]
-        * [`query_short_channel_ids_tlv_len-1`:`encoded_query_flags`]
+    * [`tlvs`:`query_short_channel_ids_tlvs`]
 
-</a>
+1. tlvs: `query_short_channel_ids_tlv`
+2. types:
+    1. type: 1 (`query_flags`)
+    2. data:
+        * [`byte`:`encoding_type`]
+        * [`len-1`:`encoded_query_flags`]
 
 `encoded_query_flags` is an array of bitfields, one varint per bitfield, one bitfield for each `short_channel_id`. Bits have the following meaning:
 
@@ -635,7 +636,7 @@ The sender:
   - MAY send this if it receives a `channel_update` for a
    `short_channel_id` for which it has no `channel_announcement`.
   - SHOULD NOT send this if the channel referred to is not an unspent output.
-  - MAY include an optional `query_short_channel_ids_tlv`. If so:
+  - MAY include an optional `query_flags`. If so:
     - MUST set `encoding_type`, as for `encoded_short_ids`.
     - Each query flag is a minimally-encoded varint.
     - MUST encode one query flag per `short_channel_id`.
@@ -647,7 +648,7 @@ The receiver:
     - MAY fail the connection.
   - if it has not sent `reply_short_channel_ids_end` to a previously received `query_short_channel_ids` from this sender:
     - MAY fail the connection.
-  - if the incoming message includes `query_short_channel_ids_tlv`:
+  - if the incoming message includes `query_short_channel_ids_tlvs`:
     - if `encoding_type` is not a known encoding type:
       - MAY fail the connection
     - if `encoded_query_flags` does not decode to exactly one flag per `short_channel_id`:
@@ -692,9 +693,12 @@ timeouts.  It also causes a natural ratelimiting of queries.
     * [`chain_hash`:`chain_hash`]
     * [`u32`:`first_blocknum`]
     * [`u32`:`number_of_blocks`]
-    * [`query_channel_range_tlv`]
-      * type: 1 (`query_option`)
-      * data:
+    * [`tlvs`:`query_channel_range_tlvs`]
+
+1. tlvs: `query_channel_range_tlvs`
+2. types:
+    1. type: 1 (`query_option`)
+    2. data:
         * [`1`:`query_option_flags`]
 
 `query_option_flags` is a bitfield represented as a minimally-encoded varint. Bits have the following meaning:
@@ -714,19 +718,24 @@ Though it is possible, it would not be very useful to ask for checksums without 
     * [`byte`:`complete`]
     * [`u16`:`len`]
     * [`len*byte`:`encoded_short_ids`]
-    * [`reply_channel_range_tlv`]
-      * type: 1 (`timestamps_tlv`)
-      * data:
-        * [`1`:`encoding_type`]
-        * [`timestamps_tlv_len-1`:`encoded_timestamps`]
-      * type: 3 (`checksums_tlv`)
-      * data:
-        * [`checksums_tlv_len`:`encoded_checksums`]
+    * [`tlvs`:`reply_channel_range_tlvs`]
+
+1. tlvs: `query_channel_range_tlvs`
+2. types:
+    1. type: 1 (`timestamps_tlv`)
+    2. data:
+        * [`byte`:`encoding_type`]
+        * [`len-1`:`encoded_timestamps`]
+    1. type: 3 (`checksums_tlv`)
+    2. data:
+        * [`len`:`encoded_checksums`]
 
 For a single `channel_update`, timestamps are encoded as:
 
-* [`4`:`timestamp_node_id_1`]
-* [`4`:`timestamp_node_id_2`]
+1. subtype: `channel_update_timestamps`
+2. data:
+    * [`u32`:`timestamp_node_id_1`]
+    * [`u32`:`timestamp_node_id_2`]
 
 Where:
 * `timestamp_node_id_1` is the timestamp of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
@@ -734,8 +743,10 @@ Where:
 
 For a single `channel_update`, checksums are encoded as:
 
-* [`4`:`checksum_node_id_1`]
-* [`4`:`checksum_node_id_2`]
+1. subtype: `channel_update_checksums`
+2. data:
+    * [`u32`:`checksum_node_id_1`]
+    * [`u32`:`checksum_node_id_2`]
 
 Where:
 * `checksum_node_id_1` is the checksum of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
@@ -771,7 +782,7 @@ The receiver of `query_channel_range`:
     - otherwise:
       - SHOULD set `complete` to 1.
 
-If the incoming message includes a `query_channel_range_tlv` that it understands, the receiver MAY append additional information to its reply.
+If the incoming message includes `query_option`, the receiver MAY append additional information to its reply:
 - if bit 0 in `query_option_flags` is set, the receive MAY append a `timestamps_tlv` that contains `channel_update` timestamps for all `short_chanel_id`s in `encoded_short_ids`
 - if bit 1 in `query_option_flags` is set, the receive MAY append a `checksums_tlv` that contains `channel_update` checksums for all `short_chanel_id`s in `encoded_short_ids`
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -753,7 +753,7 @@ Where:
 * `checksum_node_id_1` is the checksum of the `channel_update` for `node_id_1`, or 0 if there was no `channel_update` from that node.
 * `checksum_node_id_2` is the checksum of the `channel_update` for `node_id_2`, or 0 if there was no `channel_update` from that node.
 
-The checksum of a `channel_update` is the CRC32 checksum of this `channel_update` without its `signature` and `timestamp` fields.
+The checksum of a `channel_update` is the CRC32C checksum as specified in [RFC3720](https://tools.ietf.org/html/rfc3720#appendix-B.4) of this `channel_update` without its `signature` and `timestamp` fields.
 
 This allows to query for channels within specific blocks.
 

--- a/09-features.md
+++ b/09-features.md
@@ -20,12 +20,13 @@ see [BOLT #1: The `init` Message](01-messaging.md#the-init-message).
 
 These flags may only be used in the `init` message:
 
-| Bits | Name                             | Description                                                               | Link                         |
-|------|----------------------------------|---------------------------------------------------------------------------|------------------------------|
-| 0/1  | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields                   | [BOLT #2][bolt02-retransmit] |
-| 3    | `initial_routing_sync`           | Indicates that the sending node needs a complete routing information dump | [BOLT #7][bolt07-sync]       |
-| 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2][bolt02-open]       |
-| 6/7  | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07-query]      |
+| Bits  | Name                             | Description                                                               | Link                         |
+|-------|----------------------------------|---------------------------------------------------------------------------|------------------------------|
+| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields                   | [BOLT #2][bolt02-retransmit] |
+| 3     | `initial_routing_sync`           | Indicates that the sending node needs a complete routing information dump | [BOLT #7][bolt07-sync]       |
+| 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2][bolt02-open]       |
+| 6/7   | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07-query]      |
+| 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information                         | [BOLT #7][bolt07-query]      |
 
 ## Assigned `globalfeatures` flags
 
@@ -34,7 +35,6 @@ The following `globalfeatures` bits are currently assigned by this specification
 | Bits | Name              | Description                                                        | Link                                  |
 |------|-------------------|--------------------------------------------------------------------|---------------------------------------|
 | 8/9  | `var_onion_optin` | This node requires/supports variable-length routing onion payloads | [Routing Onion Specification][bolt04] |
-
 
 ## Requirements
 

--- a/bolt07/extended-queries.json
+++ b/bolt07/extended-queries.json
@@ -1,0 +1,263 @@
+[
+    {
+        "hex": "01070f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206000186a0000005dc", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "firstBlockNum": 100000, 
+            "numberOfBlocks": 1500, 
+            "tlvStream": {
+                "records": [], 
+                "unknown": []
+            }, 
+            "type": "QueryChannelRange"
+        }
+    }, 
+    {
+        "hex": "01070f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206000088b800000064010103", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "firstBlockNum": 35000, 
+            "numberOfBlocks": 100, 
+            "tlvStream": {
+                "records": [
+                    "WANT_TIMESTAMPS | WANT_CHECKSUMS"
+                ], 
+                "unknown": []
+            }, 
+            "type": "QueryChannelRange"
+        }
+    }, 
+    {
+        "hex": "01080f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206000b8a06000005dc01001900000000000000008e0000000000003c69000000000045a6c4", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "complete": 1, 
+            "firstBlockNum": 756230, 
+            "numberOfBlocks": 1500, 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x142", 
+                    "0x0x15465", 
+                    "0x69x42692"
+                ], 
+                "encoding": "UNCOMPRESSED"
+            }, 
+            "type": "ReplyChannelRange"
+        }
+    }, 
+    {
+        "hex": "01080f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206000006400000006e01001601789c636000833e08659309a65878be010010a9023a", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "complete": 1, 
+            "firstBlockNum": 1600, 
+            "numberOfBlocks": 110, 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x142", 
+                    "0x0x15465", 
+                    "0x4x3318"
+                ], 
+                "encoding": "COMPRESSED_ZLIB"
+            }, 
+            "type": "ReplyChannelRange"
+        }
+    }, 
+    {
+        "hex": "01080f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e22060001ddde000005dc01001900000000000000304300000000000778d6000000000046e1c1011900000282c1000e77c5000778ad00490ab00000b57800955bff031800000457000008ae00000d050000115c000015b300001a0a", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "checksums": {
+                "checksums": [
+                    {
+                        "checksum1": 1111, 
+                        "checksum2": 2222
+                    }, 
+                    {
+                        "checksum1": 3333, 
+                        "checksum2": 4444
+                    }, 
+                    {
+                        "checksum1": 5555, 
+                        "checksum2": 6666
+                    }
+                ]
+            }, 
+            "complete": 1, 
+            "firstBlockNum": 122334, 
+            "numberOfBlocks": 1500, 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x12355", 
+                    "0x7x30934", 
+                    "0x70x57793"
+                ], 
+                "encoding": "UNCOMPRESSED"
+            }, 
+            "timestamps": {
+                "encoding": "UNCOMPRESSED", 
+                "timestamps": [
+                    {
+                        "timestamp1": 164545, 
+                        "timestamp2": 948165
+                    }, 
+                    {
+                        "timestamp1": 489645, 
+                        "timestamp2": 4786864
+                    }, 
+                    {
+                        "timestamp1": 46456, 
+                        "timestamp2": 9788415
+                    }
+                ]
+            }, 
+            "type": "ReplyChannelRange"
+        }
+    }, 
+    {
+        "hex": "01080f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e22060001ddde000005dc01001801789c63600001036730c55e710d4cbb3d3c080017c303b1012201789c63606a3ac8c0577e9481bd622d8327d7060686ad150c53a3ff0300554707db031800000457000008ae00000d050000115c000015b300001a0a", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "checksums": {
+                "checksums": [
+                    {
+                        "checksum1": 1111, 
+                        "checksum2": 2222
+                    }, 
+                    {
+                        "checksum1": 3333, 
+                        "checksum2": 4444
+                    }, 
+                    {
+                        "checksum1": 5555, 
+                        "checksum2": 6666
+                    }
+                ]
+            }, 
+            "complete": 1, 
+            "firstBlockNum": 122334, 
+            "numberOfBlocks": 1500, 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x12355", 
+                    "0x7x30934", 
+                    "0x70x57793"
+                ], 
+                "encoding": "COMPRESSED_ZLIB"
+            }, 
+            "timestamps": {
+                "encoding": "COMPRESSED_ZLIB", 
+                "timestamps": [
+                    {
+                        "timestamp1": 164545, 
+                        "timestamp2": 948165
+                    }, 
+                    {
+                        "timestamp1": 489645, 
+                        "timestamp2": 4786864
+                    }, 
+                    {
+                        "timestamp1": 46456, 
+                        "timestamp2": 9788415
+                    }
+                ]
+            }, 
+            "type": "ReplyChannelRange"
+        }
+    }, 
+    {
+        "hex": "01050f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206001900000000000000008e0000000000003c69000000000045a6c4", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x142", 
+                    "0x0x15465", 
+                    "0x69x42692"
+                ], 
+                "encoding": "UNCOMPRESSED"
+            }, 
+            "tlvStream": {
+                "records": [], 
+                "unknown": []
+            }, 
+            "type": "QueryShortChannelIds"
+        }
+    }, 
+    {
+        "hex": "01050f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206001801789c63600001c12b608a69e73e30edbaec0800203b040e", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x4564", 
+                    "0x2x47550", 
+                    "0x69x42692"
+                ], 
+                "encoding": "COMPRESSED_ZLIB"
+            }, 
+            "tlvStream": {
+                "records": [], 
+                "unknown": []
+            }, 
+            "type": "QueryShortChannelIds"
+        }
+    }, 
+    {
+        "hex": "01050f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e22060019000000000000002fc80000000000003cc4000000000045a6c4010c01789c6364620100000e0008", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x12232", 
+                    "0x0x15556", 
+                    "0x69x42692"
+                ], 
+                "encoding": "UNCOMPRESSED"
+            }, 
+            "tlvStream": {
+                "records": [
+                    {
+                        "array": [
+                            1, 
+                            2, 
+                            4
+                        ], 
+                        "encoding": "COMPRESSED_ZLIB"
+                    }
+                ], 
+                "unknown": []
+            }, 
+            "type": "QueryShortChannelIds"
+        }
+    }, 
+    {
+        "hex": "01050f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206001801789c63600001f30a30c5b0cd144cb92e3b020017c6034a010c01789c6364620100000e0008", 
+        "msg": {
+            "chainHash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 
+            "shortChannelIds": {
+                "array": [
+                    "0x0x14200", 
+                    "0x0x46645", 
+                    "0x69x42692"
+                ], 
+                "encoding": "COMPRESSED_ZLIB"
+            }, 
+            "tlvStream": {
+                "records": [
+                    {
+                        "array": [
+                            1, 
+                            2, 
+                            4
+                        ], 
+                        "encoding": "COMPRESSED_ZLIB"
+                    }
+                ], 
+                "unknown": []
+            }, 
+            "type": "QueryShortChannelIds"
+        }
+    }
+]
+


### PR DESCRIPTION
This is a new pull requests that supersedes #519 .

It addresses issues with the original proposal, mainly that it defined a new set of messages, adding complexity to a simple gossip protocol that we knew was limited in the first place.

This proposal does not add new messages, or feature bits, and is fully compatible with existing implementations. Instead of defining new messages it extends existing ones with additional data, that will be ignored by nodes which do not implement extended queries (see [BOLT #1](01-messaging.md)).

Nodes that support extended queries will append an additional extended query flag to their `query_channel_range` queries. If the receiver supports extended queries and understands this flag, it will append the requested additional data to its `reply_channel_range` message.

There is currently only one type of additional data: one timestamp and one checksum per `channel_update`.
The checksum is a simple Adler32 checksum computed over the `channel_update` with `timestamp` and `signature` omitted.
Together they can be used to avoid querying `channel_updates` that are older than the ones you already have, or that are newer but don't include new information.

Nodes can then append additional data to their `query_short_channel_ids` messages, which consists in one flag per short channel id and specifies what they would like to receive (`channel_announcement`, or/and one `channel_update` or both`).