### PR TITLE
BOLT7: reply_channel_range parameter

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -659,7 +659,7 @@ The receiver of `query_channel_range`:
     - MUST set `first_blocknum` equal to checking first block number.
     - MUST set `number_of_blocks` equal to checking number of blocks.
     - MUST encode a `short_channel_id` for every open channel it knows in blocks `first_blocknum` to `first_blocknum` plus `number_of_blocks` minus one.
-      - SHOULD set `len` to 0 if no `encoded_short_ids`.
+      - SHOULD set encoding types even if there is no channel_ids.
     - MUST limit `number_of_blocks` to the maximum number of blocks whose
       results could fit in `encoded_short_ids`
     - if does not maintain up-to-date channel information for `chain_hash`:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -656,10 +656,8 @@ The receiver of `query_channel_range`:
 	`number_of_blocks` minus one.
   - For each `reply_channel_range`:
     - MUST set with `chain_hash` equal to that of `query_channel_range`.
-    - MUST set `first_blocknum` equal to first block number of `encoded_short_ids`.
-      - SHOULD set to 0 if no `encoded_short_ids`.
-    - MUST set `number_of_blocks` equal to last block number of `encoded_short_ids` minus `first_blocknum` plus one.
-      - SHOULD set to 0 if no `encoded_short_ids`.
+    - MUST set `first_blocknum` equal to checking first block number.
+    - MUST set `number_of_blocks` equal to checking number of blocks.
     - MUST encode a `short_channel_id` for every open channel it knows in blocks `first_blocknum` to `first_blocknum` plus `number_of_blocks` minus one.
       - SHOULD set `len` to 0 if no `encoded_short_ids`.
     - MUST limit `number_of_blocks` to the maximum number of blocks whose

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -657,8 +657,11 @@ The receiver of `query_channel_range`:
   - For each `reply_channel_range`:
     - MUST set with `chain_hash` equal to that of `query_channel_range`.
     - MUST set `first_blocknum` equal to first block number of `encoded_short_ids`.
+      - SHOULD set to 0 if no `encoded_short_ids`.
     - MUST set `number_of_blocks` equal to last block number of `encoded_short_ids` minus `first_blocknum` plus one.
+      - SHOULD set to 0 if no `encoded_short_ids`.
     - MUST encode a `short_channel_id` for every open channel it knows in blocks `first_blocknum` to `first_blocknum` plus `number_of_blocks` minus one.
+      - SHOULD set `len` to 0 if no `encoded_short_ids`.
     - MUST limit `number_of_blocks` to the maximum number of blocks whose
       results could fit in `encoded_short_ids`
     - if does not maintain up-to-date channel information for `chain_hash`:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -655,7 +655,9 @@ The receiver of `query_channel_range`:
 	cover the requested `first_blocknum` to `first_blocknum` plus
 	`number_of_blocks` minus one.
   - For each `reply_channel_range`:
-    - MUST set with `chain_hash` equal to that of `query_channel_range`,
+    - MUST set with `chain_hash` equal to that of `query_channel_range`.
+    - MUST set `first_blocknum` equal to first block number of `encoded_short_ids`.
+    - MUST set `number_of_blocks` equal to last block number of `encoded_short_ids` minus `first_blocknum` plus one.
     - MUST encode a `short_channel_id` for every open channel it knows in blocks `first_blocknum` to `first_blocknum` plus `number_of_blocks` minus one.
     - MUST limit `number_of_blocks` to the maximum number of blocks whose
       results could fit in `encoded_short_ids`


### PR DESCRIPTION
[BOLT7 `reply_channel_range` requirements](https://github.com/lightningnetwork/lightning-rfc/blob/064d6feed036de192f71cf6854e00f33361b6090/07-routing-gossip.md#requirements-5)

> The receiver of query_channel_range:
>  - For each reply_channel_range: 
>     - MUST encode a `short_channel_id` for every open channel it knows in blocks `first_blocknum` to `first_blocknum` plus `number_of_blocks` minus one.

so,

`first_blocknum` = short_ids[0].block
`number_of_blocks` = short_ids[LAST].block - `first_blocknum` + 1