### PR TITLE
BOLT 11: change default expiry to 86400 seconds (1 day)

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -131,7 +131,7 @@ Currently defined tagged fields are:
 * `d` (13): `data_length` variable. Short description of purpose of payment (UTF-8), e.g. '1 cup of coffee' or 'ナンセンス 1杯'
 * `n` (19): `data_length` 53. 33-byte public key of the payee node
 * `h` (23): `data_length` 52. 256-bit description of purpose of payment (SHA256). This is used to commit to an associated description that is over 639 bytes, but the transport mechanism for the description in that case is transport specific and not defined here.
-* `x` (6): `data_length` variable. `expiry` time in seconds (big-endian). Default is 3600 (1 hour) if not specified.
+* `x` (6): `data_length` variable. `expiry` time in seconds (big-endian). Default is 86400 (1 day) if not specified.
 * `c` (24): `data_length` variable. `min_final_cltv_expiry` to use for the last HTLC in the route. Default is 9 if not specified.
 * `f` (9): `data_length` variable, depending on version. Fallback on-chain address: for Bitcoin, this starts with a 5-bit `version` and contains a witness program or P2PKH or P2SH address.
 * `r` (3): `data_length` variable. One or more entries containing extra routing information for a private route; there may be more than one `r` field


### PR DESCRIPTION
context: https://twitter.com/francispouliot_/status/1098193142170439680


> We open channel if no route found, wait 6 confs (1h), pay. Default Bolt11 expiry in C-Lightning/LND is 3600 secs (1h). Payment failures are guaranteed by default UX configs.
> 
> Should be 86400 (1 day).
> 
> The average time it takes to open a channel is exactly the time it takes for an invoice to expire. If an invoice expires, I need to send an email to the user, he must come back to the app, create a new Bolt11 w/same node, and we try again. Changing 3600 to 86400 solves it
> 

fix in c-lightning: https://github.com/FrancisPouliot/lightning/commit/3f0d93bfd919213531c07d26b84ec9cb653237f5

fix in LND: https://github.com/prusnak/lnd/commit/0b6212c3d9a88a2f66fd736647f9bc88f56c18a0
