### PR TITLE
[BOLT 08] added elaboration of Noise Protocol terms when used first

### DIFF
--- a/08-transport.md
+++ b/08-transport.md
@@ -66,7 +66,8 @@ an AEAD payload with a zero-length cipher text is sent. As this payload has no
 length, only a MAC is sent across. The mixing of ECDH outputs into
 a hash digest forms an incremental TripleDH handshake.
 
-Using the language of the Noise Protocol, `e` and `s` (both public keys)
+Using the language of the Noise Protocol, `e` and `s` (both public keys with `e` being 
+the ephemeral key and `s` being the static key which in our case is usually the `nodeid`)
 indicate possibly encrypted keying material, and `es`, `ee`, and `se` each indicate an
 ECDH operation between two keys. The handshake is laid out as follows:
 ```


### PR DESCRIPTION
When the notation of the noise protocol framework is being introduced the terms `ck` and `k` are being explained but `e` and `s` are only referred to was public keys. I fixed that by stating what they stand for and noting that `s` is usually the the `nodeid` in the context of the Lightning Network protocol.