### PR TITLE
BOLT 2 : Remove dust option in sending no-change commitment tx

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -947,7 +947,7 @@ updates.
 alters the fee.
   - MAY send a `commitment_signed` message that doesn't
 change the commitment transaction aside from the new revocation number
-(due to dust, identical HTLC replacement, or insignificant or multiple
+(identical HTLC replacement, or insignificant or multiple
 fee changes).
   - MUST include one `htlc_signature` for every HTLC transaction corresponding
   to BIP69 lexicographic ordering of the commitment transaction.


### PR DESCRIPTION
Assuming amount of to_remote or to_local output is decreased at htlc commitment, even committing a dust one should always modify commitment tx. And bolt2 also prohibits commitment tx without outputs.  