### PR TITLE
 BOLT 7: fix message name(gossip_timestamp_range -> gossip_timestamp_filter)

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -773,7 +773,7 @@ A receiving node:
 
 A node:
   - if the `gossip_queries` feature is negotiated:
-	- MUST not send gossip until it receives `gossip_timestamp_range`.
+    - MUST not send gossip until it receives `gossip_timestamp_filter`.
   - SHOULD flush outgoing gossip messages once every 60 seconds, independently of
   the arrival times of the messages.
     - Note: this results in staggered announcements that are unique (not

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -773,7 +773,7 @@ A receiving node:
 
 A node:
   - if the `gossip_queries` feature is negotiated:
-    - MUST not send gossip until it receives `gossip_timestamp_filter`.
+    - MUST NOT send gossip until it receives `gossip_timestamp_filter`.
   - SHOULD flush outgoing gossip messages once every 60 seconds, independently of
   the arrival times of the messages.
     - Note: this results in staggered announcements that are unique (not


### PR DESCRIPTION
It is prefered to be written as "gossip_timestamp_filter" instead of "gossip_stamp_range" ?
