### PR TITLE
BOLT 9: add features wumbo and wumborama

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -108,6 +108,7 @@ The sending node:
   - MUST set feature bits as defined in [BOLT #9](09-features.md).
   - MUST set any undefined feature bits to 0.
   - SHOULD use the minimum lengths required to represent the feature fields.
+  - MUST set local feature `option_i_wumbo_you_wumbo` if `option_wumborama` is set in global features.
 
 The receiving node:
   - MUST wait to receive `init` before sending any other messages.
@@ -116,6 +117,7 @@ The receiving node:
     - MUST ignore the bit.
   - upon receiving unknown _even_ feature bits that are non-zero:
     - MUST fail the connection.
+  - MUST fail the connection if the received local features have `option_i_wumbo_you_wumbo` but `option_wumborama` is not set in global features.
 
 #### Rationale
 

--- a/01-messaging.md
+++ b/01-messaging.md
@@ -117,7 +117,6 @@ The receiving node:
     - MUST ignore the bit.
   - upon receiving unknown _even_ feature bits that are non-zero:
     - MUST fail the connection.
-  - MUST fail the connection if the received local features have `option_i_wumbo_you_wumbo` but `option_wumborama` is not set in global features.
 
 #### Rationale
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -165,14 +165,18 @@ The `shutdown_scriptpubkey` allows the sending node to commit to where
 funds will go on mutual close, which the remote node should enforce
 even if a node is compromised later.
 
-[ FIXME: Describe dangerous feature bit for larger channel amounts. ]
+The `option_i_wumbo_you_wumbo` allows peers to signal that they will accept
+`funding_satoshis` greater than 2^24.
 
 #### Requirements
 
 The sending node:
   - MUST ensure the `chain_hash` value identifies the chain it wishes to open the channel within.
   - MUST ensure `temporary_channel_id` is unique from any other channel ID with the same peer.
-  - MUST set `funding_satoshis` to less than 2^24 satoshi.
+  - if both nodes advertised `option_i_wumbo_you_wumbo`:
+    - MAY set `funding_satoshis` greater than 2^24 satoshi.
+  - otherwise:
+    - MUST set `funding_satoshis` to less than 2^24 satoshi.
   - MUST set `push_msat` to equal or less than 1000 * `funding_satoshis`.
   - MUST set `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, and `delayed_payment_basepoint` to valid DER-encoded, compressed, secp256k1 pubkeys.
   - MUST set `first_per_commitment_point` to the per-commitment point to be used for the initial commitment transaction, derived as specified in [BOLT #3](03-transactions.md#per-commitment-secret-requirements).
@@ -216,15 +220,15 @@ are not valid DER-encoded compressed secp256k1 pubkeys.
   - `dust_limit_satoshis` is greater than `channel_reserve_satoshis`.
   - the funder's amount for the initial commitment transaction is not sufficient for full [fee payment](03-transactions.md#fee-payment).
   - both `to_local` and `to_remote` amounts for the initial commitment transaction are less than or equal to `channel_reserve_satoshis` (see [BOLT 3](03-transactions.md#commitment-transaction-outputs)).
+  - `funding_satoshis` is greater than 2^24 and the receiver does not support `option_i_wumbo_you_wumbo`. 
 
 The receiving node MUST NOT:
   - consider funds received, using `push_msat`, to be received until the funding transaction has reached sufficient depth.
 
 #### Rationale
 
-The requirement for `funding_satoshi` to be less than 2^24 satoshi is a temporary self-imposed limit while implementations are not yet considered stable.
-It can be lifted at any point in time, or adjusted for other currencies, since it is solely enforced by the endpoints of a channel.
-Specifically, [the routing gossip protocol](07-routing-gossip.md) does not discard channels that have a larger capacity.
+The requirement for `funding_satoshis` to be less than 2^24 satoshi was a temporary self-imposed limit while implementations were not yet considered stable.
+, it can be lifted by advertising `option_i_wumbo_you_wumbo`. 
 
 The *channel reserve* is specified by the peer's `channel_reserve_satoshis`: 1% of the channel total is suggested. Each side of a channel maintains this reserve so it always has something to lose if it were to try to broadcast an old, revoked commitment transaction. Initially, this reserve may not be met, as only one side has funds; but the protocol ensures that there is always progress toward meeting this reserve, and once met, it is maintained.
 

--- a/09-features.md
+++ b/09-features.md
@@ -26,6 +26,7 @@ These flags may only be used in the `init` message:
 | 3  | `initial_routing_sync` | Indicates that the sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
 | 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 | 6/7  | `gossip_queries`           | More sophisticated gossip control | [BOLT #7](07-routing-gossip.md#query-messages) |
+| 14/15  | `option_i_wumbo_you_wumbo`   | Can create large channels | [BOLT #2](02-peer-protocol.md#the-open_channel-message) 
 
 ## Assigned `globalfeatures` flags
 

--- a/09-features.md
+++ b/09-features.md
@@ -30,7 +30,12 @@ These flags may only be used in the `init` message:
 
 ## Assigned `globalfeatures` flags
 
-There are currently no `globalfeatures` flags.
+These flags may only be used in the `init` or `node_announcement` message:
+
+| Bits | Name             |Description                                     | Link                                                                |
+|------|------------------|------------------------------------------------|---------------------------------------------------------------------|
+| 16/17 | `option_wumborama` | Can handle large payments		   | (#Rationale) |
+
 
 ## Requirements
 
@@ -43,6 +48,10 @@ above can be found in [BOLT #1: The `init` Message](01-messaging.md#the-init-mes
 There is no _even_ bit for `initial_routing_sync`, as there would be little
 point: a local node can't determine if a remote node complies, and it must
 interpret the flag, as defined in the initial spec.
+
+The `option_wumborama` is used to let everyone know this node is willing to use `option_i_wumbo_you_wumbo` with anyone.
+Since it's broadcast in the `node_announcement` message other nodes can use it to identify peers 
+willing to accept large channel even before exchanging the `init` message with them. 
 
 ![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png "License CC-BY")
 <br>


### PR DESCRIPTION
This proposal formalizes the discussion happened on the mailing list about lifting the channel size limit. Two features are defined here:

-  `option_i_wumbo_you_wumbo` means I'm willing to accept channel larger than 2^24  (local feature)
-  `option_wumborama` means I offer and I'm willing to accept `option_i_wumbo_you_wumbo` from anyone (global feature)

Peers MUST set `option_i_wumbo_you_wumbo` in the local features of the `init` message if they set the `option_wumborama` in the global features, the proposal reuses the bits defined in #571  