### PR TITLE
BOLT 3: Explicit description of implicitly enforced timelocks on HTLC outputs

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -981,6 +981,8 @@ offline until after sending `commitment_signed`.  Once
 those HTLCs, and cannot fail the related incoming HTLCs until the
 output HTLCs are fully resolved.
 
+Note that the `htlc_signature` implicitly enforces the timelock mechanism in the case of offered HTLCs being timed out or received HTLCs being spent. This is done to reduce fees by creating smaller scripts compared to explicitly stating timelocks on HTLC outputs.
+
 ### Completing the Transition to the Updated State: `revoke_and_ack`
 
 Once the recipient of `commitment_signed` checks the signature and knows

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -981,7 +981,7 @@ offline until after sending `commitment_signed`.  Once
 those HTLCs, and cannot fail the related incoming HTLCs until the
 output HTLCs are fully resolved.
 
-Note that the `htlc_signature` implicitly enforces the timelock mechanism in the case of offered HTLCs being timed out or received HTLCs being spent. This is done to reduce fees by creating smaller scripts compared to explicitly stating timelocks on HTLC outputs.
+Note that the `htlc_signature` implicitly enforces the time-lock mechanism in the case of offered HTLCs being timed out or received HTLCs being spent. This is done to reduce fees by creating smaller scripts compared to explicitly stating time-locks on HTLC outputs.
 
 ### Completing the Transition to the Updated State: `revoke_and_ack`
 

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -147,7 +147,7 @@ If a revoked commitment transaction is published, the remote node can spend this
 
     <revocation_sig> <revocationpubkey>
 
-The sending node can use the HTLC-timeout transaction to timeout the HTLC once the HTLC is expired, as shown below. This is the only way that the local node can timeout the HTLC, since this branch requires `<remotehtlcsig>`, which ensures that the local node cannot prematurely timeout the HTLC (since the HTLC-timeout transaction is timelocked), and also must wait `to_self_delay` before accessing these funds allowing for the remote node to claim these funds if the transaction has been revoked.
+The sending node can use the HTLC-timeout transaction to timeout the HTLC once the HTLC is expired, as shown below. This is the only way that the local node can timeout the HTLC, and this branch requires `<remotehtlcsig>`, which ensures that the local node cannot prematurely timeout the HTLC since the HTLC-timeout transaction has `cltv_expiry` as its specified `locktime`. The local node must also wait `to_self_delay` before accessing these funds, allowing for the remote node to claim these funds if the transaction has been revoked.
 
 #### Received HTLC Outputs
 

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -147,7 +147,7 @@ If a revoked commitment transaction is published, the remote node can spend this
 
     <revocation_sig> <revocationpubkey>
 
-The sending node can use the HTLC-timeout transaction to timeout the HTLC once the HTLC is expired, as shown below.
+The sending node can use the HTLC-timeout transaction to timeout the HTLC once the HTLC is expired, as shown below. This is the only way that the local node can timeout the HTLC, since this branch requires `<remotehtlcsig>`, which ensures that the local node cannot prematurely timeout the HTLC (since the HTLC-timeout transaction is timelocked), and also must wait `to_self_delay` before accessing these funds allowing for the remote node to claim these funds if the transaction has been revoked.
 
 #### Received HTLC Outputs
 
@@ -178,7 +178,7 @@ If a revoked commitment transaction is published, the remote node can spend this
 
     <revocation_sig> <revocationpubkey>
 
-To redeem the HTLC, the HTLC-success transaction is used as detailed below.
+To redeem the HTLC, the HTLC-success transaction is used as detailed below. This is the only way that the local node can spend the HTLC, since this branch requires `<remotehtlcsig>`, which ensures that the local node must wait `to_self_delay` before accessing these funds allowing for the remote node to claim these funds if the transaction has been revoked.
 
 ### Trimmed Outputs
 


### PR DESCRIPTION
Added descriptions of how a 2-of-2 multisignature verification is used for enforcing timelocks when timing out on-chain offered HTLCs as well as spending on-chain received HTLCs in the success case.

I say implicitly enforced to mean that these timelocks do not show up explicitly in any of the HTLC output scripts.

It took me a lot of time and effort to reason these facts out of the existing documentation so I figured I'd propose to add it.