### PR TITLE
Specify tlv format

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -330,3 +330,4 @@ zlib
 ZLIB
 APIs
 duplicative
+CompactSize


### PR DESCRIPTION
This first commit is the same as the previous proposal, but the second makes type a varint and explicitly handles integer fields.