### PR TITLE
BOLT2: past fulfillment deadline fails channel

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -751,7 +751,7 @@ A fulfilling node:
   - MUST fail (and not forward) an HTLC whose fulfillment deadline is already past.
   - if an HTLC it has fulfilled is in either node's current commitment
   transaction, AND is past this fulfillment deadline:
-    - MUST fail the connection.
+    - MUST fail the channel.
 
 ### Adding an HTLC: `update_add_htlc`
 


### PR DESCRIPTION
This seems a typo. It seems it should say channel rather than connection.
If not, why fail the connection (presumably to reconnect later? or to ban the node?) instead of failing the channel?
Or are they just equivalent?