### PR TITLE
BOLT01: TLV proposal

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -330,3 +330,14 @@ zlib
 ZLIB
 APIs
 duplicative
+TLV
+namespace
+verifier
+verifiers
+EOF
+monotonicity
+varint
+optimizations
+structs
+CompactSize
+encodings


### PR DESCRIPTION
~~This proposal outlines a TLV format intended for wire messages. It contains additional considerations for gossip messages that would require maintaining the ability to verify signatures over unknown fields, and the ability to propagate those messages to peers.~~

~~This proposal makes different tradeoffs from #603 in terms of:~~
 - ~~requiring strict canonical encoding~~
 - ~~fixed-size length encoding~~
 - ~~supporting reserialization of unknown records~~
 - ~~using 255 as the sentinel type identifier~~
 - ~~removing even/odd requirement from the parsing logic, favoring negotiation via feature bits or application of such constraints external to the fundamental parsing requirements~~

After significant feedback and discussion, the proposal now entails:
 - `type` and `length` both use the bitcoin varint format, minimally-encoded
 - no repeated fields
 - canonical ordering is defined by sorting `type` only
 - readers must enforce canonical order
 - includes even/odd rule (fail when reading an unknown even type)
 - no sentinel value

The proposal is meant to encompass a single TLV format for use in wire and onion payloads.

Reference implementation: https://github.com/lightningnetwork/lnd/pull/3061