### PR TITLE
BOLT5: Unify two practically redundant paragraphs

### DIFF
--- a/05-onchain.md
+++ b/05-onchain.md
@@ -435,14 +435,10 @@ own timeout still applies as an upper bound.
 ## HTLC Output Handling: Remote Commitment, Remote Offers
 
 Each HTLC output can only be spent by the recipient if it uses the payment
-preimage. If a node does not possess the preimage (and doesn't discover
+preimage. In other words, the remote HTLC outputs can only be spent by the local node if
+it has the payment preimage. If the local node does not have the preimage (and doesn't discover
 it), it's the offerer's responsibility to spend the HTLC output once it's timed
 out.
-
-The remote HTLC outputs can only be spent by the local node if it has the
-payment preimage. If the local node does not have the preimage (and doesn't
-discover it), it's the remote node's responsibility to spend the HTLC output
-once it's timed out.
 
 There are actually several possible cases for an offered HTLC:
 

--- a/05-onchain.md
+++ b/05-onchain.md
@@ -434,11 +434,10 @@ own timeout still applies as an upper bound.
 
 ## HTLC Output Handling: Remote Commitment, Remote Offers
 
-Each HTLC output can only be spent by the recipient if it uses the payment
-preimage. In other words, the remote HTLC outputs can only be spent by the local node if
-it has the payment preimage. If the local node does not have the preimage (and doesn't discover
-it), it's the offerer's responsibility to spend the HTLC output once it's timed
-out.
+The remote HTLC outputs can only be spent by the local node if it has the
+payment preimage. If the local node does not have the preimage (and doesn't
+discover it), it's the remote node's responsibility to spend the HTLC output
+once it's timed out.
 
 There are actually several possible cases for an offered HTLC:
 


### PR DESCRIPTION
The two paragraph seem quite redundant and repetitive. Perhaps the resulting one can even be simplified even further.