### PR TITLE
BOLT9: Format table

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -20,12 +20,12 @@ see [BOLT #1: The `init` Message](01-messaging.md#the-init-message).
 
 These flags may only be used in the `init` message:
 
-| Bits | Name             |Description                                     | Link                                                                |
-|------|------------------|------------------------------------------------|---------------------------------------------------------------------|
-| 0/1  | `option_data_loss_protect` | Requires or supports extra `channel_reestablish` fields | [BOLT #2](02-peer-protocol.md#message-retransmission) |
-| 3  | `initial_routing_sync` | Indicates that the sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync) |
-| 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
-| 6/7  | `gossip_queries`           | More sophisticated gossip control | [BOLT #7](07-routing-gossip.md#query-messages) |
+| Bits | Name                             | Description                                                               | Link                                                    |
+|------|----------------------------------|---------------------------------------------------------------------------|---------------------------------------------------------|
+| 0/1  | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields                   | [BOLT #2](02-peer-protocol.md#message-retransmission)   |
+| 3    | `initial_routing_sync`           | Indicates that the sending node needs a complete routing information dump | [BOLT #7](07-routing-gossip.md#initial-sync)            |
+| 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
+| 6/7  | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7](07-routing-gossip.md#query-messages)          |
 
 ## Assigned `globalfeatures` flags
 


### PR DESCRIPTION
I know this is kind of stupid, but it makes it easier to read in plain text.
I totally understand if people don't think it's worth it.
It doesn't affect how github displays the file, the markdown is still correct.
