### PR TITLE
Rephrase last node payload requirements

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -291,8 +291,10 @@ using an alternate channel.
 
 When building the route, the origin node MUST use a payload for
 the final node with the following values:
-* `outgoing_cltv_value`: set to the final expiry specified by the recipient
-* `amt_to_forward`: set to the final amount specified by the recipient
+* `outgoing_cltv_value`: set to the final expiry specified by the recipient (e.g.
+  `min_final_cltv_expiry` from a [BOLT #11](11-payment-encoding.md) payment invoice)
+* `amt_to_forward`: set to the final amount specified by the recipient (e.g. `amount`
+  from a [BOLT #11](11-payment-encoding.md) payment invoice)
 
 This allows the final node to check these values and return errors if needed,
 but it also eliminates the possibility of probing attacks by the second-to-last


### PR DESCRIPTION
Mention that `outgoing_cltv_value` has to be equal to `min_final_cltv_expiry` and `amt_to_forward` has to be equal to `amount`, as seen in the invoice