### PR TITLE
BOLT4: Correct hop count clarification

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -101,7 +101,7 @@ There are a number of conventions adhered to throughout this document:
 
 # Clarifications
 
-The longest route supported has 20 hops without counting the _origin node_ and _final node_, thus 19 _intermediate nodes_ and a maximum of 20 channels to be traversed.
+The longest route supported has 20 hops without counting the _origin node_, but counting _final node_, thus 19 _intermediate nodes_ and a maximum of 20 channels to be traversed.
 
 # Key Generation
 


### PR DESCRIPTION
The 20 hop count excludes the origin but includes the final node, right? thus it's 19 intermediate nodes but 20 channels.
This feels like a typo, please, ignore me if I'm wrong.