### PR TITLE
BOLT 2: Must not send identical fee changes

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1049,6 +1049,7 @@ given in [BOLT #3](03-transactions.md#fee-calculation).
 The node _responsible_ for paying the Bitcoin fee:
   - SHOULD send `update_fee` to ensure the current fee rate is sufficient (by a
       significant margin) for timely processing of the commitment transaction.
+  - MUST NOT send identical consecutive `update_fee`s.
 
 The node _not responsible_ for paying the Bitcoin fee:
   - MUST NOT send `update_fee`.


### PR DESCRIPTION
See https://github.com/ElementsProject/lightning/issues/2701 for context.

I went with *MUST NOT* to be consistent with:

> A sending node:
>  - MUST NOT send a `commitment_signed` message that does not include any
updates.