### PR TITLE
BOLT 02: clarify that announcement_signatures is a BOLT 7 msg

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1097,10 +1097,10 @@ operation, acknowledgments of updates are delayed until the
 that the updates have been received. This also means that the receiving
 node only needs to store updates upon receipt of `commitment_signed`.
 
-Note that messages described in [BOLT #7](07-routing-gossip.md) are
-independent of particular channels; their transmission requirements
-are covered there, and besides being transmitted after `init` (as all
-messages are), they are independent of requirements here.
+Note that messages described in [BOLT #7](07-routing-gossip.md) (including
+`announcement_signatures`) are independent of particular channels; their
+transmission requirements are covered there, and besides being transmitted after
+`init` (as all messages are), they are independent of requirements here.
 
 1. type: 136 (`channel_reestablish`)
 2. data:


### PR DESCRIPTION
There seems to be some confusion as to which messages can be sent
before `channel_reestablish`. The spec says that all BOLT 7 messages
can be sent independently of the requirements of `channel_reestablish`.
This change clarifies that `announcement_signatures` are also included
categorically.