### PR TITLE
BOLT #7: receiving node requirements related to timestamp for channel_update message

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -330,3 +330,5 @@ zlib
 ZLIB
 APIs
 duplicative
+DoS
+ECDSA

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -498,8 +498,8 @@ The receiving node:
   `channel_update` for this `short_channel_id` AND for `node_id`:
     - SHOULD ignore the message.
   - otherwise:
-    - if the `timestamp` is equal to the last-received `channel_update`,
-    AND the fields differ (with a valid `signature` for the message):
+    - if the `timestamp` is equal to the last-received `channel_update` for this
+    `short_channel_id` AND `node_id`, AND the fields below `timestamp` differ:
       - MAY blacklist this `node_id`.
       - MAY forget all channels associated with it.
   - if the `timestamp` is unreasonably far in the future:
@@ -523,6 +523,13 @@ either too far in the future or have not been updated in two weeks; so it
 makes sense to have it be a UNIX timestamp (i.e. seconds since UTC
 1970-01-01). This cannot be a hard requirement, however, given the possible case
 of two `channel_update`s within a single second.
+
+It is assumed that more than one `channel_update` message changing the channel 
+parameters in the same second is a DoS attempt, and therefore, the node responsible 
+for signing such messages ought to be blacklisted. However, a node can send a same 
+`channel_update` message with a different signature (changing the nonce in signature 
+signing), and hence fields apart from signature are checked to see if the channel 
+parameters have changed for the same timestamp.
 
 The explicit `option_channel_htlc_max` flag to indicate the presence
 of `htlc_maximum_msat` (rather than having `htlc_maximum_msat` implied

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -534,7 +534,7 @@ for signing such messages may be blacklisted. However, a node may send a same
 `channel_update` message with a different signature (changing the nonce in signature 
 signing), and hence fields apart from signature are checked to see if the channel 
 parameters have changed for the same timestamp. It is also important to note that 
-ECDSA signatures are malleable. So, an intermediatary node who received the `channel_update` 
+ECDSA signatures are malleable. So, an intermediate node who received the `channel_update` 
 message can rebroadcast it just by changing the `s` component of signature with `-s`. 
 This should however not result in the blacklist of the `node_id` from where
 the message originated.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -526,10 +526,14 @@ of two `channel_update`s within a single second.
 
 It is assumed that more than one `channel_update` message changing the channel 
 parameters in the same second may be a DoS attempt, and therefore, the node responsible 
-for signing such messages may be blacklisted. However, a node can send a same 
+for signing such messages may be blacklisted. However, a node may send a same 
 `channel_update` message with a different signature (changing the nonce in signature 
 signing), and hence fields apart from signature are checked to see if the channel 
-parameters have changed for the same timestamp.
+parameters have changed for the same timestamp. It is also important to note that 
+ECDSA signatures are malleable. So, an intermediatary node who received the `channel_update` 
+message can rebroadcast it just by changing the `s` component of signature with `-s`. 
+This should however not result in the blacklist of the `node_id` from where
+the message originated.
 
 The explicit `option_channel_htlc_max` flag to indicate the presence
 of `htlc_maximum_msat` (rather than having `htlc_maximum_msat` implied

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -494,17 +494,18 @@ The receiving node:
   - if the specified `chain_hash` value is unknown (meaning it isn't active on
   the specified chain):
     - MUST ignore the channel update.
+  - if the `timestamp` is equal to the last-received `channel_update` for this
+    `short_channel_id` AND `node_id`:
+  	- if the fields below `timestamp` differ:
+		- MAY blacklist this `node_id`.
+		- MAY forget all channels associated with it.
+	- if the fields below `timestamp` are equal:
+		- SHOULD ignore this message	
   - if `timestamp` is lower than that of the last-received
   `channel_update` for this `short_channel_id` AND for `node_id`:
     - SHOULD ignore the message.
   - otherwise:
-    - if the `timestamp` is equal to the last-received `channel_update` for this
-    `short_channel_id` AND `node_id`,
-    	- if the fields below `timestamp` are equal:
-		- SHOULD ignore this message
-    	- if the fields below `timestamp` differ:
-    		- MAY blacklist this `node_id`.
-      		- MAY forget all channels associated with it.
+    
   - if the `timestamp` is unreasonably far in the future:
     - MAY discard the `channel_update`.
   - otherwise:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -499,9 +499,12 @@ The receiving node:
     - SHOULD ignore the message.
   - otherwise:
     - if the `timestamp` is equal to the last-received `channel_update` for this
-    `short_channel_id` AND `node_id`, AND the fields below `timestamp` differ:
-      - MAY blacklist this `node_id`.
-      - MAY forget all channels associated with it.
+    `short_channel_id` AND `node_id`, 
+    	- if the fields below `timestamp` differ:
+    		- MAY blacklist this `node_id`.
+      		- MAY forget all channels associated with it.
+	- if the fields below `timestamp` are equal:
+		- SHOULD ignore this message
   - if the `timestamp` is unreasonably far in the future:
     - MAY discard the `channel_update`.
   - otherwise:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -525,7 +525,7 @@ makes sense to have it be a UNIX timestamp (i.e. seconds since UTC
 of two `channel_update`s within a single second.
 
 It is assumed that more than one `channel_update` message changing the channel 
-parameters in the same second is a DoS attempt, and therefore, the node responsible 
+parameters in the same second may be a DoS attempt, and therefore, the node responsible 
 for signing such messages ought to be blacklisted. However, a node can send a same 
 `channel_update` message with a different signature (changing the nonce in signature 
 signing), and hence fields apart from signature are checked to see if the channel 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -494,7 +494,7 @@ The receiving node:
   - if the specified `chain_hash` value is unknown (meaning it isn't active on
   the specified chain):
     - MUST ignore the channel update.
-  - if `timestamp` is NOT greater than OR equal to that of the last-received
+  - if `timestamp` is lower than that of the last-received
   `channel_update` for this `short_channel_id` AND for `node_id`:
     - SHOULD ignore the message.
   - otherwise:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -499,12 +499,12 @@ The receiving node:
     - SHOULD ignore the message.
   - otherwise:
     - if the `timestamp` is equal to the last-received `channel_update` for this
-    `short_channel_id` AND `node_id`, 
+    `short_channel_id` AND `node_id`,
+    	- if the fields below `timestamp` are equal:
+		- SHOULD ignore this message
     	- if the fields below `timestamp` differ:
     		- MAY blacklist this `node_id`.
       		- MAY forget all channels associated with it.
-	- if the fields below `timestamp` are equal:
-		- SHOULD ignore this message
   - if the `timestamp` is unreasonably far in the future:
     - MAY discard the `channel_update`.
   - otherwise:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -494,12 +494,12 @@ The receiving node:
   - if the specified `chain_hash` value is unknown (meaning it isn't active on
   the specified chain):
     - MUST ignore the channel update.
-  - if `timestamp` is NOT greater than that of the last-received
+  - if `timestamp` is NOT greater than OR equal to that of the last-received
   `channel_update` for this `short_channel_id` AND for `node_id`:
     - SHOULD ignore the message.
   - otherwise:
-    - if the `timestamp` is equal to the last-received `channel_update`
-    AND the fields (other than `signature`) differ:
+    - if the `timestamp` is equal to the last-received `channel_update`,
+    AND the fields differ (with a valid `signature` for the message):
       - MAY blacklist this `node_id`.
       - MAY forget all channels associated with it.
   - if the `timestamp` is unreasonably far in the future:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -526,7 +526,7 @@ of two `channel_update`s within a single second.
 
 It is assumed that more than one `channel_update` message changing the channel 
 parameters in the same second may be a DoS attempt, and therefore, the node responsible 
-for signing such messages ought to be blacklisted. However, a node can send a same 
+for signing such messages may be blacklisted. However, a node can send a same 
 `channel_update` message with a different signature (changing the nonce in signature 
 signing), and hence fields apart from signature are checked to see if the channel 
 parameters have changed for the same timestamp.


### PR DESCRIPTION
While going through BOLT #7 I was confused by this receiving node requirement for `channel_update` message: "if the `timestamp` is equal to the last-received `channel_update` AND the fields (other than `signature`) differ: MAY blacklist this `node_id`; MAY forget all channels associated with it." On the outset it might read to "`timestamp` should be same, the `signature` should be same as previous but if the other data is different; then blacklist the `node_id`". However, if `signature` is same as previous update but data is different, then the `signature` would be rendered invalid. And since `signature` check is done prior to the `timestamp` check, this situation of checking may not arise. So this check seems to be redundant. However, Mark H corrected me on stackexchange (https://bitcoin.stackexchange.com/questions/88350/bolt-7-can-receiving-node-requirements-in-channel-update-message-give-rise-to) by saying that a valid `signature` must be provided for this `channel_update` and `timestamp` to go through. This pull request slightly corrects the language behind this check and adds a paragraph in the rationale to explain that point. 

In correcting the point, I have said fields below `timestamp` differs for the following reason: (1) `short_channel_id` and `chain_hash` requirements are processed prior to `timestamp` and (2) valid `signature` check is also done prior to the `timestamp`.

While creating this pull request, I also noticed a slight typo in the same section. The sentence prior to the one I mentioned above says that if the `timestamp` is not greater than the previous message, the node should ignore the message. And the second sentence is about comparing if `timestamp` is equal. But again, the equal to check might not be processed as the message will be discarded if it is not greater. I have changed that to "greater than or equal to". Would love your comments and suggestions.