### PR TITLE
BOLT7: (announcement_signatures) Fail channel if `short_channel_id` not correct.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -84,7 +84,7 @@ A node:
 
 A recipient node:
   - if the `short_channel_id` is NOT correct:
-    - MAY fail the channel.
+    - SHOULD fail the channel.
   - if the `node_signature` OR the `bitcoin_signature` is NOT correct:
     - MAY fail the channel.
   - if it has sent AND received a valid `announcement_signatures` message:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -83,6 +83,8 @@ A node:
       - SHOULD retransmit the `announcement_signatures` message.
 
 A recipient node:
+  - if the `short_channel_id` is NOT correct:
+    - MAY fail the channel.
   - if the `node_signature` OR the `bitcoin_signature` is NOT correct:
     - MAY fail the channel.
   - if it has sent AND received a valid `announcement_signatures` message:


### PR DESCRIPTION
`announcement_signatures`

Fail channel if `short_channel_id` not correct.