### PR TITLE
BOLT 5 : data_loss let you salvage received HTLC on remote commitment

### DIFF
--- a/05-onchain.md
+++ b/05-onchain.md
@@ -364,9 +364,9 @@ recognize all of the *remote node's* commitment transaction HTLC outputs. It can
 detect the data loss state, because it has signed the transaction, and the
 commitment number is greater than expected. If both nodes support
 `option_data_loss_protect`, the local node will possess the remote's
-`per_commitment_point`, and thus can derive its own `remotepubkey` for the
-transaction, in order to salvage its own funds. Note: in this scenario, the node
-will be unable to salvage the HTLCs.
+`per_commitment_point`, and thus can derive its own `remotepubkey` and 
+ remote_htlcpubkey`for the transaction, in order to salvage its own funds,
+including HTLCs by timeout or preimage.
 
 ## HTLC Output Handling: Remote Commitment, Local Offers
 


### PR DESCRIPTION
Thanks to data_loss_protect, your remote peer is going to give you his current per_commitment_point if channel_reestablish are exchanged. If he owns a fully-signed commitment_transaction and broadcast it, using your basepoints you should be able to derive keys even for remote_htlcpubkey and get back, non only your to_remote output, but also HTLC outputs.