### PR TITLE
BOLT01: swap CompactSize for BigSize in TLV format

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -341,3 +341,5 @@ optimizations
 structs
 CompactSize
 encodings
+bigsize
+BigSize

--- a/tools/spellcheck.sh
+++ b/tools/spellcheck.sh
@@ -51,6 +51,7 @@ do
     if [ -n "$CHECK" ]; then
 	# Eliminate the following:
 	# Inline references eg. [Use of segwit](#use-of-segwit)
+	# Code blocks using ```
 	# quoted identifiers eg. `htlc_id`
 	# field descriptions, eg. `* [`num_htlcs*64`:`htlc_signature]'
 	# indented field names, eg. '    `num_htlcs`: 0'
@@ -60,6 +61,7 @@ do
 	# long hex strings
 	# long base58 strings
 	WORDS=$(sed -e 's/\]([-#a-zA-Z0-9_.]*)//g' \
+	    -e '/^```/,/^```/d' \
 	    -e 's/`[a-zA-Z0-9_]*`//g' \
 	    -e 's/\* \[`[_a-z0-9*]\+`://g' \
 	    -e 's/0x[a-fA-F0-9]\+//g' \


### PR DESCRIPTION
This commit modifies the varint encoding used for TLV types and lengths
to use a custom format called BigSize. The format is identical to
bitcoin's CompactSize, except it replaces the use of little-endian
encodings for multi-byte values with big-endian. This is done to prevent
mixing endianness within the protocol, since otherwise CompactSize would
be the first introduction of little-endian encodings.