### PR TITLE
BOLT07: don't send historical updates for gossip_timestamp_filter

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -698,10 +698,6 @@ The sender:
   that it wants the gossip to refer to.
 
 The receiver:
-  - SHOULD send all gossip messages whose `timestamp` is greater or
-    equal to `first_timestamp`, and less than `first_timestamp` plus
-    `timestamp_range`.
-	- MAY wait for the next outgoing gossip flush to send these.
   - SHOULD restrict future gossip messages to those whose `timestamp`
     is greater or equal to `first_timestamp`, and less than
     `first_timestamp` plus `timestamp_range`.


### PR DESCRIPTION
This commit removes the suggestion for nodes to respond with all known
updates that satisfy the timestamps of a gossip_timestamp_filter
message. This behavior is identical to using the `initial_routing_sync`,
which has been deprecated due to the inefficient nature of sending the
entire graph on every connection. Now, the requirements simply say that
only new messages should be sent to peers.

Given the upcoming addition of `extended_gossip_queries`,
implementations should use this feature to locate missing graph
information instead of relying the on the remote peer to dump
everything.