### PR TITLE
BOLT 7: update interpretation of `complete` field within query messages

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -679,10 +679,10 @@ The receiver of `query_channel_range`:
     - MUST encode a `short_channel_id` for every open channel it knows in blocks `first_blocknum` to `first_blocknum` plus `number_of_blocks` minus one.
     - MUST limit `number_of_blocks` to the maximum number of blocks whose
       results could fit in `encoded_short_ids`
-    - if does not maintain up-to-date channel information for `chain_hash`:
-      - MUST set `complete` to 0.
+    - the last `reply_channel_range` being sent as a response:
+      - MUST set `complete` to 1.
     - otherwise:
-      - SHOULD set `complete` to 1.
+      - MUST set `complete` to 0.
 
 #### Rationale
 


### PR DESCRIPTION
The current interpretation seems to have been copied over from reply_short_channel_ids_end. That message should only be sent once at the end, so the interpretation there makes sense. This is not the case for reply_channel_range however, since multiple of these messages can be sent. When responding to a query_channel_range, if the response spans multiple messages and the message being sent is not the last one, the field should be `0`, otherwise `1`.