### PR TITLE
BOLT #7: Correct indentation typo in channel_update message

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -501,20 +501,20 @@ The receiving node:
     - MUST ignore the channel update.
   - if the `timestamp` is equal to the last-received `channel_update` for this
     `short_channel_id` AND `node_id`:
-  	- if the fields below `timestamp` differ:
-		- MAY blacklist this `node_id`.
-		- MAY forget all channels associated with it.
-	- if the fields below `timestamp` are equal:
-		- SHOULD ignore this message	
+    - if the fields below `timestamp` differ:
+      - MAY blacklist this `node_id`.
+      - MAY forget all channels associated with it.
+    - if the fields below `timestamp` are equal:
+      - SHOULD ignore this message	
   - if `timestamp` is lower than that of the last-received
   `channel_update` for this `short_channel_id` AND for `node_id`:
-  	- SHOULD ignore the message.
+    - SHOULD ignore the message.
   - otherwise:
-  	- if the `timestamp` is unreasonably far in the future:
-		- MAY discard the `channel_update`.
-  	- otherwise:
-		- SHOULD queue the message for rebroadcasting.
-		- MAY choose NOT to for messages longer than the minimum expected length.
+    - if the `timestamp` is unreasonably far in the future:
+      - MAY discard the `channel_update`.
+    - otherwise:
+      - SHOULD queue the message for rebroadcasting.
+      - MAY choose NOT to for messages longer than the minimum expected length.
   - if the `option_channel_htlc_max` bit of `message_flags` is 0:
     - MUST consider `htlc_maximum_msat` not to be present.
   - otherwise:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -508,14 +508,13 @@ The receiving node:
 		- SHOULD ignore this message	
   - if `timestamp` is lower than that of the last-received
   `channel_update` for this `short_channel_id` AND for `node_id`:
-    - SHOULD ignore the message.
+  	- SHOULD ignore the message.
   - otherwise:
-    
-  - if the `timestamp` is unreasonably far in the future:
-    - MAY discard the `channel_update`.
-  - otherwise:
-    - SHOULD queue the message for rebroadcasting.
-    - MAY choose NOT to for messages longer than the minimum expected length.
+  	- if the `timestamp` is unreasonably far in the future:
+		- MAY discard the `channel_update`.
+  	- otherwise:
+		- SHOULD queue the message for rebroadcasting.
+		- MAY choose NOT to for messages longer than the minimum expected length.
   - if the `option_channel_htlc_max` bit of `message_flags` is 0:
     - MUST consider `htlc_maximum_msat` not to be present.
   - otherwise:


### PR DESCRIPTION
Related to pull [#621 ](https://github.com/lightningnetwork/lightning-rfc/pull/621#discussion_r304777931)

Corrected the indentation in the otherwise section in the `timestamp` check of the `channel_update` message. Both the actions that needed to be taken appeared at the same level which had to be indented.