### PR TITLE
Bolt 04: fix a few left-over spelling / clean-up nits

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -20,20 +20,20 @@ see [BOLT #1: The `init` Message](01-messaging.md#the-init-message).
 
 These flags may only be used in the `init` message:
 
-| Bits | Name                             | Description                                                               | Link                   |
-|------|----------------------------------|---------------------------------------------------------------------------|------------------------|
-| 0/1  | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields                   | [BOLT #2][bolt02]      |
-| 3    | `initial_routing_sync`           | Indicates that the sending node needs a complete routing information dump | [BOLT #7][bolt07]      |
-| 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2][bolt02open]  |
-| 6/7  | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07query] |
+| Bits | Name                             | Description                                                               | Link                         |
+|------|----------------------------------|---------------------------------------------------------------------------|------------------------------|
+| 0/1  | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields                   | [BOLT #2][bolt02-retransmit] |
+| 3    | `initial_routing_sync`           | Indicates that the sending node needs a complete routing information dump | [BOLT #7][bolt07-sync]       |
+| 4/5  | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2][bolt02-open]       |
+| 6/7  | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07-query]      |
 
 ## Assigned `globalfeatures` flags
 
 The following `globalfeatures` bits are currently assigned by this specification:
 
-| Bits | Name              | Description                                                 | Link                                  |
-|------|-------------------|-------------------------------------------------------------|---------------------------------------|
-| 8/9  | `var_onion_optin` | This node requires/supports variable payload routing onions | [routing onion specification][bolt04] |
+| Bits | Name              | Description                                                        | Link                                  |
+|------|-------------------|--------------------------------------------------------------------|---------------------------------------|
+| 8/9  | `var_onion_optin` | This node requires/supports variable-length routing onion payloads | [Routing Onion Specification][bolt04] |
 
 
 ## Requirements
@@ -51,8 +51,9 @@ interpret the flag, as defined in the initial spec.
 ![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png "License CC-BY")
 <br>
 This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).
-[bolt02]: 02-peer-protocol.md#message-retransmission
-[bolt02open]: 02-peer-protocol.md#the-open_channel-message
+
+[bolt02-retransmit]: 02-peer-protocol.md#message-retransmission
+[bolt02-open]: 02-peer-protocol.md#the-open_channel-message
 [bolt04]: 04-onion-routing.md
-[bolt07]: 07-routing-gossip.md#initial-sync
-[bolt07query]: 07-routing-gossip.md#query-messages
+[bolt07-sync]: 07-routing-gossip.md#initial-sync
+[bolt07-query]: 07-routing-gossip.md#query-messages


### PR DESCRIPTION
* Removed mentions of the deprecated `hops_data` field
* Formatting

Nothing fancy to see here ;)