### PR TITLE
BOLT7: channel_update after exchange funding_locked

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -441,7 +441,7 @@ or `node_id_2` otherwise.
 
 The origin node:
   - MAY create a `channel_update` to communicate the channel parameters to the
-  channel peer, even though the channel has not yet been announced (i.e. the
+  channel peer after `funding_locked` has been received, even though the channel has not yet been announced (i.e. the
   `announce_channel` bit was not set).
     - MUST NOT forward such a `channel_update` to other peers, for privacy
     reasons.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -440,8 +440,9 @@ or `node_id_2` otherwise.
 ### Requirements
 
 The origin node:
+  - MUST NOT send a created `channel_update` before `funding_locked` has been received.
   - MAY create a `channel_update` to communicate the channel parameters to the
-  channel peer after `funding_locked` has been received, even though the channel has not yet been announced (i.e. the
+  channel peer, even though the channel has not yet been announced (i.e. the
   `announce_channel` bit was not set).
     - MUST NOT forward such a `channel_update` to other peers, for privacy
     reasons.


### PR DESCRIPTION
If a node sends its own `channel_update` to a peer node before receiving a `funding_lock`, the peer node may discard because it has not `short_channel_id` yet.

```
ex: node-A and node-B check blockchain every 30 seconds.

  node-A                    node-B
    |                         |
  ~~~ funding_tx is in block ~~~
    |                         |
 [detect new block]           |
 [calc short_channel_id]      |
 [create channel_update]      |
    |                         |
    |---funding_locked------->|
    |---channel_update------->|
    |                         |cannot compare short_channel_id
    |                         |  ===> discard channel_update
    |                         |
    |                         |
    |                  [detect new block]
    |                  [calc short_channel_id]
    |                  [create channel_update]
    |                         |
    |<-------funding_locked---|
    |<-------channel_update---|
compare short_channel_id      |
  ===> accept channel_update  |
    |                         |
    |                         |
```
