### PR TITLE
BOLT 4: Define custom tlv type range

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -108,7 +108,11 @@ messages, a `tlv_stream` is typically placed after all currently defined fields.
 
 The `type` is a varint encoded using the BigSize format. It functions as a
 message-specific, 64-bit identifier for the `tlv_record` determining how the
-contents of `value` should be decoded.
+contents of `value` should be decoded. `type` identifiers below 2^16 are
+reserved for use in this specification. `type` identifiers greater than or equal
+to 2^16 are available for custom records. Any record not defined in this
+specification is considered a custom record. This includes experimental and
+application-specific messages.
 
 The `length` is a varint encoded using the BigSize format signaling the size of
 `value` in bytes.
@@ -121,6 +125,13 @@ according to the message-specific format determined by `type`.
 The sending node:
  - MUST order `tlv_record`s in a `tlv_stream` by monotonically-increasing `type`.
  - MUST minimally encode `type` and `length`.
+ - When defining custom record `type` identifiers:
+   - SHOULD pick random `type` identifiers to avoid collision with other
+     custom types.
+   - SHOULD pick odd `type` identifiers when regular nodes should ignore the
+     additional data.
+   - SHOULD pick even `type` identifiers when regular nodes should reject the
+     full tlv stream containing the custom record.
  - SHOULD NOT use redundant, variable-length encodings in a `tlv_record`.
 
 The receiving node:


### PR DESCRIPTION
This PR defines a type range for custom tlv records. The goal is to prevent unofficial fields from allocating identifiers in the official range. This could cause problems when new fields are added to this specification and turn out to collide with custom records that are used in the wild.