### PR TITLE
Added explicit mention of uppercase invoices

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -40,6 +40,7 @@ A reader:
   - MUST parse the address as Bech32, as specified in BIP-0173 (also without the character limit).
   - if the checksum is incorrect:
     - MUST fail the payment.
+  - MUST accept uppercase invoices as well, and convert to full lowercase for the sake of parsing and checking checksums.
 
 # Human-Readable Part
 


### PR DESCRIPTION
#659 
Added explicit mention that readers must accept uppercase invoices which are generated by some providers, especially for the purpose of smaller QR codes.