### PR TITLE
BOLT04: use truncated u64 encoding for next_hop_id

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -247,7 +247,7 @@ This is a more flexible format, which avoids the redundant `short_channel_id` fi
         * [`tu32`:`outgoing_cltv_value`]
     1. type: 6 (`short_channel_id`)
     2. data:
-        * [`short_channel_id`:`short_channel_id`]
+        * [`tu64`:`short_channel_id`]
 
 ### Requirements
 


### PR DESCRIPTION
As per [discussion in this thread](https://github.com/lightningnetwork/lightning-rfc/pull/619#discussion_r318875465), this PR changes the `short_channel_id` onion record (type 8) from `short_channel_id` to `tu64`, which shaves 8 bytes for the final hop when the `short_channel_id` is always 0.

@cdecker do you have any thoughts on [how do to this mapping](https://github.com/lightningnetwork/lightning-rfc/pull/619#discussion_r319075787)? Is that something that should be in this PR?