### PR TITLE
Flat features: far simpler solution for feature bits.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -371,3 +371,4 @@ tlvs
 snprintf
 GitHub
 IRC
+bitmasks

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -187,8 +187,6 @@ The `shutdown_scriptpubkey` allows the sending node to commit to where
 funds will go on mutual close, which the remote node should enforce
 even if a node is compromised later.
 
-[ FIXME: Describe dangerous feature bit for larger channel amounts. ]
-
 #### Requirements
 
 The sending node:
@@ -263,12 +261,6 @@ would be eliminated as dust.  The similar requirements in
 are above both `dust_limit_satoshis`.
 
 Details for how to handle a channel failure can be found in [BOLT 5:Failing a Channel](05-onchain.md#failing-a-channel).
-
-#### Future
-
-It would be easy to have a local feature bit which indicated that a
-receiving node was prepared to fund a channel, which would reverse this
-protocol.
 
 ### The `accept_channel` Message
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -188,9 +188,7 @@ The receiving node:
   - MUST verify the integrity AND authenticity of the message by verifying the
   signatures.
   - if there is an unknown even bit in the `features` field:
-    - MUST NOT parse the remainder of the message.
-    - MUST NOT add the channel to its local network view.
-    - SHOULD NOT forward the announcement.
+    - MUST NOT attempt to route messages through the channel.
   - if the `short_channel_id`'s output does NOT correspond to a P2WSH (using
     `bitcoin_key_1` and `bitcoin_key_2`, as specified in
     [BOLT #3](03-transactions.md#funding-transaction-output)) OR the output is
@@ -244,8 +242,6 @@ New channel features are possible in the future: backwards compatible (or
 optional) features will have _odd_ feature bits, while incompatible features
 will have _even_ feature bits
 (["It's OK to be odd!"](00-introduction.md#glossary-and-terminology-guide)).
-Incompatible features will result in the announcement not being forwarded by
-nodes that do not understand them.
 
 ## The `node_announcement` Message
 
@@ -326,11 +322,7 @@ any future fields appended to the end):
     - SHOULD fail the connection.
     - MUST NOT process the message further.
   - if `features` field contains _unknown even bits_:
-    - MUST NOT parse the remainder of the message.
-    - MAY discard the message altogether.
     - SHOULD NOT connect to the node.
-  - MAY forward `node_announcement`s that contain an _unknown_ `features` _bit_,
-  regardless of if it has parsed the announcement or not.
   - SHOULD ignore the first `address descriptor` that does NOT match the types
   defined above.
   - if `addrlen` is insufficient to hold the address descriptors of the
@@ -354,8 +346,9 @@ any future fields appended to the end):
 
 New node features are possible in the future: backwards compatible (or
 optional) ones will have _odd_ `feature` _bits_, incompatible ones will have
-_even_ `feature` _bits_. These may be propagated by nodes even if they
-cannot process the announcements themselves.
+_even_ `feature` _bits_. These will be propagated normally; incompatible
+feature bits here refer to the nodes, not the `node_announcement` message
+itself.
 
 New address types may be added in the future; as address descriptors have
 to be ordered in ascending order, unknown ones can be safely ignored.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -180,7 +180,8 @@ The origin node:
   - MUST set `bitcoin_signature_1` and `bitcoin_signature_2` to valid
   signatures of the hash `h` (using `bitcoin_key_1` and `bitcoin_key_2`'s
   respective secrets).
-  - SHOULD set `len` to the minimum length required to hold the `features` bits
+  - MUST set `features` based on what features were negotiated for this channel, according to [BOLT #9](09-features.md#assigned-features-flags)
+  - MUST set `len` to the minimum length required to hold the `features` bits
   it sets.
 
 The receiving node:
@@ -311,6 +312,7 @@ The origin node:
   to 0.
   - SHOULD ensure `ipv4_addr` AND `ipv6_addr` are routable addresses.
   - MUST NOT include more than one `address descriptor` of the same type.
+  - MUST set `features` according to [BOLT #9](09-features.md#assigned-features-flags)
   - SHOULD set `flen` to the minimum length required to hold the `features`
   bits it sets.
 

--- a/09-features.md
+++ b/09-features.md
@@ -24,6 +24,7 @@ The Context column decodes as follows:
 * `C`: presented in the `channel_announcement` message.
 * `C-`: presented in the `channel_announcement` message, but always odd (optional).
 * `C+`: presented in the `channel_announcement` message, but always even (required).
+* `9`: presented in [BOLT 11](11-payment-encoding.md) invoices.
 
 | Bits  | Name                             | Description                                               | Context  | Link                                  |
 |-------|----------------------------------|-----------------------------------------------------------|----------|---------------------------------------|

--- a/09-features.md
+++ b/09-features.md
@@ -1,14 +1,10 @@
 # BOLT #9: Assigned Feature Flags
 
-This document tracks the assignment of `localfeatures` and `globalfeatures`
-flags in the `init` message ([BOLT #1](01-messaging.md)) along with the
-`features` flag fields in the `channel_announcement` and `node_announcement`
-messages ([BOLT #7](07-routing-gossip.md)).
-The flags are tracked separately, since new flags will likely be added over time.
-
-The `features` flags in the routing messages are a subset of the
-`globalfeatures` flags, as `localfeatures`, by definition, are only of interest
-to direct peers.
+This document tracks the assignment of `features` flags in the `init`
+message ([BOLT #1](01-messaging.md)), as well as `features` fields in
+the `channel_announcement` and `node_announcement` messages ([BOLT
+#7](07-routing-gossip.md)).  The flags are tracked separately, since
+new flags will likely be added over time.
 
 Flags are numbered from the least-significant bit, at bit 0 (i.e. 0x1,
 an _even_ bit). They are generally assigned in pairs so that features
@@ -16,28 +12,40 @@ can be introduced as optional (_odd_ bits) and later upgraded to be compulsory
 (_even_ bits), which will be refused by outdated nodes:
 see [BOLT #1: The `init` Message](01-messaging.md#the-init-message).
 
-## Assigned `localfeatures` flags
+Some features don't make sense on a per-channels or per-node basis, so
+each feature defines how it is presented in those contexts.  Some
+features may be required for opening a channel, but not a requirement
+for use of the channel, so the presentation of those features depends
+on the feature itself.
 
-These flags may only be used in the `init` message:
+The Context column decodes as follows:
+* `I`: presented in the `init` message.
+* `N`: presented in the `node_announcement` messages
+* `C`: presented in the `channel_announcement` message.
+* `C-`: presented in the `channel_announcement` message, but always odd (optional).
+* `C+`: presented in the `channel_announcement` message, but always even (required).
 
-| Bits  | Name                             | Description                                                               | Link                         |
-|-------|----------------------------------|---------------------------------------------------------------------------|------------------------------|
-| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields                   | [BOLT #2][bolt02-retransmit] |
-| 3     | `initial_routing_sync`           | Indicates that the sending node needs a complete routing information dump | [BOLT #7][bolt07-sync]       |
-| 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2][bolt02-open]       |
-| 6/7   | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07-query]      |
-| 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information                         | [BOLT #7][bolt07-query]      |
-| 12/13| `option_static_remotekey`     | Static key for remote output                                              | [BOLT #3](03-transactions.md)    |
-
-## Assigned `globalfeatures` flags
-
-The following `globalfeatures` bits are currently assigned by this specification:
-
-| Bits | Name              | Description                                                        | Link                                  |
-|------|-------------------|--------------------------------------------------------------------|---------------------------------------|
-| 8/9  | `var_onion_optin` | This node requires/supports variable-length routing onion payloads | [Routing Onion Specification][bolt04] |
+| Bits  | Name                             | Description                                               | Context  | Link                                  |
+|-------|----------------------------------|-----------------------------------------------------------|----------|---------------------------------------|
+| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields   | IN       | [BOLT #2][bolt02-retransmit]          |
+| 3     | `initial_routing_sync`           | Sending node needs a complete routing information dump    | I        | [BOLT #7][bolt07-sync]                |
+| 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel   | IN       | [BOLT #2][bolt02-open]                |
+| 6/7   | `gossip_queries`                 | More sophisticated gossip control                         | IN       | [BOLT #7][bolt07-query]               |
+| 8/9   | `var_onion_optin`                | Requires/supports variable-length routing onion payloads  | IN       | [Routing Onion Specification][bolt04] |
+| 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information         | IN       | [BOLT #7][bolt07-query]               |
+| 12/13| `option_static_remotekey`         | Static key for remote output                              | IN       | [BOLT #3](03-transactions.md)         |
 
 ## Requirements
+
+The origin node:
+  * If it supports a feature above, SHOULD set the corresponding odd
+    bit in all feature fields indicated by the Context column unless
+	indicated that it must set the even feature bit instead.
+  * If it requires a feature above, MUST set the corresponding even
+    feature bit in all feature fields indicated by the Context column,
+    unless indicated that it must set the odd feature bit instead.
+  * MUST NOT set feature bits it does not support.
+  * MUST NOT set feature bits in fields not specified by the table above.
 
 The requirements for receiving specific bits are defined in the linked sections in the table above.
 The requirements for feature bits that are not defined

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -272,7 +272,8 @@ Don't be like the school of [Little Bobby Tables](https://xkcd.com/327/).
 ## Feature Bits
 
 Feature bits allow forward and backward compatibility, and follow the
-_it's ok to be odd_ rule.
+_it's ok to be odd_ rule.  Features appropriate for use in the `9` field
+are marked in [BOLT 9](09-features.md).
 
 The field is big-endian.  The least-significant bit is numbered 0,
 which is _even_, and the next most significant bit is numbered 1,


### PR DESCRIPTION
We simply specify how they're presented in the three different contexts.

Consider these theoretical future features:

`opt_dlog_chan`: a new channel type which uses a new discrete log HTLC
type, but can't support traditional HTLC:

* `init`: presents as odd (optional) or even (if traditional channels
  not supported)
* `node_announcement`: the same as above, so you can seek suitable peers.
* `channel_announcement`: presents as even (compulsory), since users need
  to use the new HTLCs.

`opt_wumbochan`: a node which allows channels > 2^24 satoshis:

* `init`: presents as odd (optional), or maybe even (if you only want
  giant channels)
* `node_announcement`: the same as above, so you can seek suitable peers.
* `channel_announcement`: not present, since size of channel indicates
  capacity.

`opt_wumbohtlc`: a channel which allows HTLCs > 2^32 millisatoshis:

* `init`: presents as odd (optional), or even (compulsory)
* `node_announcement`: the same as above, so you can seek suitable peers.
* `channel_announcement`: odd (optional) since you can use the channel
  without understanding what this option means.

Closes: #571 