### PR TITLE
Bolt 11: add a payment secret to invoice

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -241,7 +241,7 @@ This is a more flexible format, which avoids the redundant `short_channel_id` fi
 2. types:
     1. type: 1 (`payment_secret`)
     2. data:
-        * [`u16`:`payment_secret`]
+        * [`16*byte`:`payment_secret`]
     1. type: 2 (`amt_to_forward`)
     2. data:
         * [`tu64`:`amt_to_forward`]


### PR DESCRIPTION
It is currently very easy for a forwarding node to discover if the next node is the recipient.
Imagine for example that we use the following route:

```
Alice -> Bob -> Carol -> Dave
```

When Carol receives the HTLC from Bob, instead of normally forwarding the onion, she can instead
create a new one-hop payment to Dave with the payment hash, amount and cltv that she would have
forwarded.

If Dave fulfills the HTLC, then he was the recipient and Carol can forward the HTLC fulfill,
completing the payment normally.
If Dave returns an error, he isn't the recipient and Carol resumes the normal payment flow by
sending him the peeled onion received from Bob.

This is a very cheap de-anonymization attack. Fortunately, it is also quite easy to fix by adding
a payment secret in the invoice that the payer needs to include in the last hop payload.

For backwards-compatibility with legacy payers, we use feature bits in the invoice to allow payees
to generate both invoices that require this payment_secret and invoices that don't (but hopefully
in a few releases we can make all implementations set this bit to mandatory by default).