### PR TITLE
BOLT 2: `option_shutdown_anysegwit` (Feature 26/27)

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -386,3 +386,4 @@ csv
 CHECKSIGVERIFY
 IFDUP
 sats
+anysegwit

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -492,7 +492,10 @@ A sending node:
    (pay to pubkey hash), OR
     2. `OP_HASH160` `20` 20-bytes `OP_EQUAL` (pay to script hash), OR
     3. `OP_0` `20` 20-bytes (version 0 pay to witness pubkey hash), OR
-    4. `OP_0` `32` 32-bytes (version 0 pay to witness script hash)
+    4. `OP_0` `32` 32-bytes (version 0 pay to witness script hash), OR
+    5. if (and only if) `option_shutdown_anysegwit` is negotiated:
+      * `OP_1` through `OP_16` inclusive, followed by a single push of 2 to 40 bytes
+	    (witness program versions 1 through 16)
 
 A receiving node:
   - if it hasn't received a `funding_signed` (if it is a funder) or a `funding_created` (if it is a fundee):

--- a/09-features.md
+++ b/09-features.md
@@ -40,6 +40,7 @@ The Context column decodes as follows:
 | 18/19 | `option_support_large_channel`   | Can create large channels                                 | IN       |                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 | 20/21 | `option_anchor_outputs`          | Anchor outputs                                            | IN       | `option_static_remotekey` | [BOLT #3](03-transactions.md)         |
 | 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
+| 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`              | IN       |                   | [BOLT #2][bolt02-shutdown]   |
 
 ## Requirements
 
@@ -82,6 +83,7 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 [bolt02-retransmit]: 02-peer-protocol.md#message-retransmission
 [bolt02-open]: 02-peer-protocol.md#the-open_channel-message
 [bolt03-htlc-tx]: 03-transactions.md#htlc-timeout-and-htlc-success-transactions
+[bolt02-shutdown]: 02-peer-protocol.md#closing-initiation-shutdown
 [bolt04]: 04-onion-routing.md
 [bolt07-sync]: 07-routing-gossip.md#initial-sync
 [bolt07-query]: 07-routing-gossip.md#query-messages


### PR DESCRIPTION
In bitcoin 0.19.0, standardness rules are going to be relaxed to allow
future witness versions.  Once this is widely deployed, it will be safe
to accept them, smoothing use of future segwit versions.

See: https://github.com/bitcoin/bitcoin/pull/15846

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>