### PR TITLE
BOLT 7: gossip_query_ex typos.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -728,7 +728,7 @@ Though it is possible, it would not be very useful to ask for checksums without 
     * [`len*byte`:`encoded_short_ids`]
     * [`reply_channel_range_tlvs`:`tlvs`]
 
-1. tlvs: `query_channel_range_tlvs`
+1. tlvs: `reply_channel_range_tlvs`
 2. types:
     1. type: 1 (`timestamps_tlv`)
     2. data:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -603,6 +603,7 @@ Nodes can signal that they support extended gossip queries with the `gossip_quer
 2. types:
     1. type: 1 (`query_flags`)
     2. data:
+        * [`u8`:`encoding_type`]
         * [`...*byte`:`encoded_query_flags`]
 
 `encoded_query_flags` is an array of bitfields, one varint per bitfield, one bitfield for each `short_channel_id`. Bits have the following meaning:
@@ -732,6 +733,7 @@ Though it is possible, it would not be very useful to ask for checksums without 
 2. types:
     1. type: 1 (`timestamps_tlv`)
     2. data:
+	    * [`u8`:`encoding_type`]
         * [`...*byte`:`encoded_timestamps`]
     1. type: 3 (`checksums_tlv`)
     2. data:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -737,7 +737,7 @@ Though it is possible, it would not be very useful to ask for checksums without 
         * [`...*byte`:`encoded_timestamps`]
     1. type: 3 (`checksums_tlv`)
     2. data:
-        * [`...*byte`:`checksums`]
+        * [`...*channel_update_checksums`:`checksums`]
 
 For a single `channel_update`, timestamps are encoded as:
 


### PR DESCRIPTION
These fixes make our implementation compile again :)  They match what we had implemented, and what the spec actually says, too.