### PR TITLE
BOLT 11: make UPPERCASE explicit.

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -35,10 +35,12 @@ encoding.
 
 A writer:
    - MUST encode the payment request in Bech32 (see BIP-0173)
+   - SHOULD use upper case for QR codes (see BIP-0173)
    - MAY exceed the 90-character limit specified in BIP-0173.
 
 A reader:
   - MUST parse the address as Bech32, as specified in BIP-0173 (also without the character limit).
+	- Note: this includes handling uppercase as specified by BIP-0173
   - if the checksum is incorrect:
     - MUST fail the payment.
 


### PR DESCRIPTION
Explicitly mirror the BIP-173 advice for QR codes, and note the reader
requirements.  In addition, we change the case of one of the examples
to ensure testing.

Fixes: #659
Alternative-to: #661 