### PR TITLE
BOLT-09: move static remote to global feature bit

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -27,7 +27,6 @@ These flags may only be used in the `init` message:
 | 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel                   | [BOLT #2][bolt02-open]       |
 | 6/7   | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07-query]      |
 | 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information                         | [BOLT #7][bolt07-query]      |
-| 12/13| `option_static_remotekey`     | Static key for remote output                                              | [BOLT #3](03-transactions.md)    |
 
 ## Assigned `globalfeatures` flags
 
@@ -36,6 +35,7 @@ The following `globalfeatures` bits are currently assigned by this specification
 | Bits | Name              | Description                                                        | Link                                  |
 |------|-------------------|--------------------------------------------------------------------|---------------------------------------|
 | 8/9  | `var_onion_optin` | This node requires/supports variable-length routing onion payloads | [Routing Onion Specification][bolt04] |
+| 12/13| `option_static_remotekey`     | Static key for remote output                                              | [BOLT #3](03-transactions.md)    |
 
 ## Requirements
 


### PR DESCRIPTION
In this commit, we move the new static remote feature bit from a local
feature bit, to a global feature bit. This should be a global bit as
peers will want to seek out others peers based on if they support the
new safety feature or not. Having it as a local feature bit means they
need to connect out, and complete the handshake before finally being
able to determine if a peer supports this new safety feature or not.