### PR TITLE
option_scid_assign: privacy protection for private channels.

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -371,3 +371,6 @@ tlvs
 snprintf
 GitHub
 IRC
+scid
+unassigning
+misrouting

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1146,6 +1146,8 @@ is illegal to send them to peers which do not offer `option_scid_assign`.
 A sending node:
   - if it did not offer `option_scid_assign`:
     - MUST NOT send `assign_scids` or `unassign_scids`
+  - if the channel has not exchanged `funding_locked`:
+    - MUST NOT send `assign_scids` or `unassign_scids`
   - MUST NOT set `assign_scids` `num` to more than 256.
   - MUST NOT set `assign_scids` `num` to less than the previous number of assigned short_channel_ids.
   - SHOULD use a unique node_id in invoices for each of the `short_channel_ids`

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1154,7 +1154,7 @@ A receiving node:
   - on receiving `assign_scid`:
     - MUST assign an unpredictable unique 64-bit number to this channel
       (see [Assigned `short_channel_id` Forwarding](04-onion-routing.md#assigned-short_channel_id-forwarding)).
-	  and return it in an ``assign_scid_reply` message.
+	  and return it in an `assign_scid_reply` message.
 	  - SHOULD ensure this does not conflict with future `short_channel_id`s.
     - MUST discard any previous assigned `short_channel_id` for this channel
   - on receiving `unassign_scid`:

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1131,6 +1131,7 @@ is illegal to send them to peers which do not offer `option_scid_assign`.
    * [`u16`:`num`]
 
 1. type: 266 (`assign_scids_reply`) (`option_scid_assign`)
+2. data:
    * [`channel_id`:`channel_id`]
    * [`u16`:`num`]
    * [`num*short_channel_id`:`scid_series`]

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1129,15 +1129,15 @@ is illegal to send them to peers which do not offer `option_scid_assign`.
 2. data:
    * [`channel_id`:`channel_id`]
 
-1. type: 268 (`assign_scid_reply`) (`option_scid_assign`)
+1. type: 266 (`assign_scid_reply`) (`option_scid_assign`)
    * [`channel_id`:`channel_id`]
    * [`short_channel_id`:`short_channel_id`]
 
-1. type: 270 (`unassign_scid`) (`option_scid_assign`)
+1. type: 268 (`unassign_scid`) (`option_scid_assign`)
 2. data:
    * [`channel_id`:`channel_id`]
 
-1. type: 272 (`unassign_scid_reply`) (`option_scid_assign`)
+1. type: 270 (`unassign_scid_reply`) (`option_scid_assign`)
    * [`channel_id`:`channel_id`]
 
 #### Requirements

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -181,17 +181,17 @@ for the first commitment transaction,
 
 The following table specifies the meaning of individual `channel_flags` bits:
 
-| Bit Position  | Name               |
-| ------------- | ------------------ |
-| 0             | `announce_channel` |
-| 1             | `disable_incoming` |
+| Bit Position  | Name                   |
+| ------------- | ---------------------- |
+| 0             | `announce_channel`     |
+| 1             | `disable_funding_scid` |
 
 `announce_channel` indicates whether the initiator of
 the funding flow wishes to advertise this channel publicly to the
 network, as detailed within [BOLT #7](07-routing-gossip.md#bolt-7-p2p-node-and-channel-discovery).
 
-`disable_incoming` indicates that no payments are to be accepted for this
-channel: this is only effective if `announce_channel` is not set, and the
+`disable_funding_scid` indicates that no payments are to be accepted for this
+channel via its funding-transaction-based `short_channel_id`.   This only makes sense if `announce_channel` is not set, and the
 recipient offers `option_scid_assign`.  See [Assigning Random
 `short_channel_id`](#assigning-random-short-channel-id).
 
@@ -1165,8 +1165,8 @@ A receiving node:
 #### Rationale
 
 There are two ways of hiding a private channel's funding-transaction-derived
-`short_channel_id`.  The most thorough is `disable_incoming` which ensures
-that the private `short_channel_id` is never used for forwarding.  However,
+`short_channel_id`.  The most thorough is `disable_funding_scid` which ensures
+that the original private `short_channel_id` is never used for forwarding.  However,
 since channels may have been opened before `option_scid_assign` was
 implemented, assigning or unassigning a random short_channel_id has the same
 effect of disabling the original `short_channel_id`.  See [Assigned
@@ -1178,11 +1178,7 @@ recommended that they only be assigned when they're actually likely to be
 used, and unassigned afterwards.
 
 If it were to conflict with a future `short_channel_id` for a real
-channel, misrouting may occur.  The simplest way to minimize this is
-to use old block numbers, but that also reduces the search space.
-Simpler is to select a random value which isn't already used, and
-close (before funding_locked) any future channel unfortunate enough to
-clash.
+channel, misrouting may occur.
 
 Assigning and unassigning are idempotent, so can be safely retransmitted in
 case of packet loss.

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -808,6 +808,13 @@ is destined, is described in [BOLT #4](04-onion-routing.md).
    * [`sha256`:`payment_hash`]
    * [`u32`:`cltv_expiry`]
    * [`1366*byte`:`onion_routing_packet`]
+   * [`update_add_htlc_tlvs`:`tlvs`]
+
+1. tlvs: `update_add_htlc_tlvs`
+2. types:
+   1. type: 1 (`forwarding`)
+   2. data:
+      * [`short_channel_id`:`via`]
 
 #### Requirements
 
@@ -829,6 +836,13 @@ Fees") while maintaining its channel reserve.
   - for the first HTLC it offers:
     - MUST set `id` to 0.
   - MUST increase the value of `id` by 1 for each successive offer.
+  - if there is more than one entry in the `scid_series` for the recipient:
+    - MUST include `via`
+  - otherwise:
+    - MAY include `via`
+  - if `via` is included, and the `update_add_htlc` was caused
+    by an incoming HTLC:
+    - `via` must match that incoming HTLC onion `short_channel_id`.
 
 `id` MUST NOT be reset to 0 after the update is complete (i.e. after `revoke_and_ack` has
 been received). It MUST continue incrementing instead.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -352,23 +352,6 @@ Alternatively, implementations may choose to apply non-strict forwarding only to
 like-policy channels to ensure their expected fee revenue does not deviate by
 using an alternate channel.
 
-## Assigned `short_channel_id` Forwarding
-
-A node SHOULD forward an HTLC to an outgoing channel if the
-`short_channel_id` matches the `short_channel_id` given in the latest
-`assign_scid_reply` message for that channel.
-
-### Rationale
-
-Private channels can hide their actual funding transaction information
-by having their peer assign a (random) short_channel_id for their use
-(i.e. in BOLT 11 invoices), if `option_scid_assign` is offered by the
-peer.
-
-Note the requirements in [Failure Messages](#failure-messages) which
-disable the use of the original `short_channel_id` once assigned
-`short_channel_id`s are used.
-
 # Shared Secret
 
 The origin node establishes a shared secret with each hop along the route using
@@ -821,11 +804,7 @@ the onion.
 
 1. type: PERM|10 (`unknown_next_peer`)
 
-The onion specified a `short_channel_id` which doesn't match any
-leading from the processing node, or it's the funding-transaction-based
-`short_channel_id` for a private channel which has
-`disable_funding_scid` set or has ever used `assign_scid`
-(in either direction).
+The onion specified a `short_channel_id` isn't in the `scid_series` for any peer:
 
 1. type: UPDATE|11 (`amount_below_minimum`)
 2. data:
@@ -969,12 +948,6 @@ A _forwarding node_ MAY, but a _final node_ MUST NOT:
     - return a `required_channel_feature_missing` error.
   - if the receiving peer specified by the onion is NOT known:
     - return an `unknown_next_peer` error.
-  - if it supports `option_scid_assign` and the `short_channel_id` is the
-    funding-transaction-based `short_channel_id` of a channel opened with
-    `announce_channel` `false`:
-	- if the peer opened or accepted the channel with `disable_funding_scid` `true` or
-      this node has ever sent the peer `assign_scid_reply` or `unassign_scid_reply`:
-      - MUST return an `unknown_next_peer` error.
   - if the HTLC amount is less than the currently specified minimum amount:
     - report the amount of the outgoing HTLC and the current channel setting for
     the outgoing channel.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -824,7 +824,8 @@ the onion.
 The onion specified a `short_channel_id` which doesn't match any
 leading from the processing node, or it's the funding-transaction-based
 `short_channel_id` for a private channel which has
-`disable_incoming` set or has a random `short_channel_id` assigned.
+`disable_funding_scid` set or has ever used `assign_scid`
+(in either direction).
 
 1. type: UPDATE|11 (`amount_below_minimum`)
 2. data:
@@ -971,7 +972,7 @@ A _forwarding node_ MAY, but a _final node_ MUST NOT:
   - if it supports `option_scid_assign` and the `short_channel_id` is the
     funding-transaction-based `short_channel_id` of a channel opened with
     `announce_channel` `false`:
-	- if the peer opened or accepted the channel with `disable_incoming` `true` or
+	- if the peer opened or accepted the channel with `disable_funding_scid` `true` or
       this node has ever sent the peer `assign_scid_reply` or `unassign_scid_reply`:
       - MUST return an `unknown_next_peer` error.
   - if the HTLC amount is less than the currently specified minimum amount:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -446,8 +446,8 @@ The origin node:
   `announce_channel` bit was not set).
     - MUST NOT forward such a `channel_update` to other peers, for privacy
     reasons.
-	- MUST use the funding-transaction-derived `short_channel_id` even if
-	  `assign_scid` has been used.
+    - MUST use the funding-transaction-derived `short_channel_id` even if
+      `assign_scids` has been used.
     - Note: such a `channel_update`, one not preceded by a
     `channel_announcement`, is invalid to any other peer and would be discarded.
   - MUST set `signature` to the signature of the double-SHA256 of the entire

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -446,6 +446,8 @@ The origin node:
   `announce_channel` bit was not set).
     - MUST NOT forward such a `channel_update` to other peers, for privacy
     reasons.
+	- MUST use the funding-transaction-derived `short_channel_id` even if
+	  `assign_scid` has been used.
     - Note: such a `channel_update`, one not preceded by a
     `channel_announcement`, is invalid to any other peer and would be discarded.
   - MUST set `signature` to the signature of the double-SHA256 of the entire

--- a/09-features.md
+++ b/09-features.md
@@ -28,6 +28,7 @@ These flags may only be used in the `init` message:
 | 6/7   | `gossip_queries`                 | More sophisticated gossip control                                         | [BOLT #7][bolt07-query]      |
 | 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information                         | [BOLT #7][bolt07-query]      |
 | 12/13| `option_static_remotekey`     | Static key for remote output                                              | [BOLT #3](03-transactions.md)    |
+| 114/115| `option_scid_assign`              | Random short-channel-id assignment                                        | [BOLT #2](bolt03-assign-scid)|
 
 ## Assigned `globalfeatures` flags
 


### PR DESCRIPTION
This turned out to be a bit more complex than I expected.

Private channels expose their funding transaction in routehints to
receive payments, but this is unnecesary.  Their funding tx can also
be probed via payment attempts.

1. A new feature, so you know when you can use these controls.
2. A channel_flags bit so you can ensure that new channels are
   protected probes from the start.
3. Messages to assign (and unassign) random short_channel_ids,
   with a side-effect of disabling the funding-tx-based one.

Fixes: #675