### PR TITLE
BOLT 11: add optional vendor field.

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -141,6 +141,7 @@ Currently defined tagged fields are:
    * `fee_base_msat` (32 bits, big-endian)
    * `fee_proportional_millionths` (32 bits, big-endian)
    * `cltv_expiry_delta` (16 bits, big-endian)
+* `v` (12): `data_length` variable.  Optional name of vendor/supplier (UTF-8).
 * `9` (5): `data_length` variable. One or more 5-bit values containing features
   supported or required for receiving this payment.
   See [Feature Bits](#feature-bits).


### PR DESCRIPTION
It was pointed out to me at thelightningconference.com that it's often
a legal requirement to list the vendor on a receipt.  It also makes
perfect sense.

It can be done in the description field, but that's really supposed to
be a description of the *items*.  Dividing it also lets wallets have
much better UX.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>