### PR TITLE
*Require* payment_secret for multi-part payments

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -310,6 +310,7 @@ The writer:
     - MUST ensure that the total `amount_msat` of the HTLC set which arrives at the payee
       is equal to `total_msat`.
     - MUST NOT send another HTLC if the total `amount_msat` of the HTLC set is already greater or equal to `total_msat`.
+    - MUST include `payment_secret`.
   - otherwise:
     - MUST set `total_msat` equal to `amt_to_forward`.
 
@@ -330,6 +331,7 @@ The final node:
       - MUST fail all HTLCs in the HTLC set after some reasonable timeout.
         - SHOULD wait for at least 60 seconds after the initial HTLC.
         - SHOULD use `mpp_timeout` for the failure message.
+      - MUST require `payment_secret` for all HTLCs in the set.
     - if it fulfills any HTLCs in the HTLC set:
        - MUST fulfill the entire HTLC set.
 

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -284,7 +284,10 @@ which is _odd_.
 
 Note that the `payment_secret` feature prevents probing attacks from nodes
 along the path, but only if made compulsory: yet doing so will break
-older clients which do not understand the feature.
+older clients which do not understand the feature.  It is compulsory
+for `basic_mpp` however, as that is also a recent feature, and makes
+nodes more vulnerable to probing attacks as there is no lower-bound
+on the amount sent.
 
 ### Requirements
 
@@ -297,9 +300,10 @@ A writer:
     - MUST set the even feature `payment_secret`.
   - If the final node supports [Basic multi-part payments](04-onion-routing.md#basic-multi-part-payments):
     - MUST set the `basic_mpp` feature.
+    - MUST set the `payment_secret` feature.
   - Otherwise:
     - MUST NOT set the `basic_mpp` feature.
-  - if it sets either `payment_secret` or `basic_mpp` features:
+  - if it sets the `payment_secret` feature:
     - MUST set the `var_onion_optin` feature.
   - MUST set `var_onion_optin` if and only if it supports that feature.
 


### PR DESCRIPTION
~(Based on #643 so ignore first three commits)~

This means the BOLT11 invoice must offer it (we already say it must set the field if it offers it), and that the receiving node must require it (again, we already say it must check it if it requires it).

Without the payment_secret, MPP payments are especially vulnerable to probing attacks: unlike normal payments (with amounts) they can be detected with 1msat payment probes.
