### PR TITLE
BOLT4: don't allow a "fee" for the final node(failure messages)

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -1076,7 +1076,7 @@ An _intermediate hop_ MUST NOT, but the _final node_:
   - if the `outgoing_cltv_value` does NOT correspond with the `cltv_expiry` from
   the final node's HTLC:
     - MUST return `final_incorrect_cltv_expiry` error.
-  - if the `amt_to_forward` is greater than the `incoming_htlc_amt` from the
+  - if the `amt_to_forward` does NOT correspond with the `incoming_htlc_amt` from the
   final node's HTLC:
     - MUST return a `final_incorrect_htlc_amount` error.
 


### PR DESCRIPTION
#711

> For the final node, this value MUST be exactly equal to the incoming htlc amount, otherwise the HTLC should be rejected.