### PR TITLE
09+11: require transitive feature dependencies

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -255,6 +255,8 @@ The receiving node:
     - MUST ignore the bit.
   - upon receiving unknown _even_ feature bits that are non-zero:
     - MUST fail the connection.
+  - if the feature vector does not set all known, transitive dependencies:
+    - MUST fail the connection.
 
 #### Rationale
 

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -48,7 +48,12 @@ A node:
   * [Key Generation](#key-generation)
   * [Pseudo Random Byte Stream](#pseudo-random-byte-stream)
   * [Packet Structure](#packet-structure)
+    * [Legacy HopData Payload Format](#legacy-hop_data-payload-format)
+    * [TLV Payload Format](#tlv_payload-format)
+    * [Basic Multi-Part Payments](#basic-multi-part-payments)
+  * [Accepting and Forwarding a Payment](#accepting-and-forwarding-a-payment)
     * [Payload for the Last Node](#payload-for-the-last-node)
+    * [Non-strict Forwarding](#non-strict-forwarding)
   * [Shared Secret](#shared-secret)
   * [Blinding Ephemeral Keys](#blinding-ephemeral-keys)
   * [Packet Construction](#packet-construction)
@@ -235,7 +240,7 @@ When forwarding HTLCs, nodes MUST construct the outgoing HTLC as specified
 within `hop_data` above; otherwise, deviation from the specified HTLC
 parameters may lead to extraneous routing failure.
 
-### `tlv_payload` payload format
+### `tlv_payload` format
 
 This is a more flexible format, which avoids the redundant `short_channel_id` field for the final node. 
 

--- a/09-features.md
+++ b/09-features.md
@@ -26,17 +26,17 @@ The Context column decodes as follows:
 * `C+`: presented in the `channel_announcement` message, but always even (required).
 * `9`: presented in [BOLT 11](11-payment-encoding.md) invoices.
 
-| Bits  | Name                             | Description                                               | Context  | Link                                  |
-|-------|----------------------------------|-----------------------------------------------------------|----------|---------------------------------------|
-| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields   | IN       | [BOLT #2][bolt02-retransmit]          |
-| 3     | `initial_routing_sync`           | Sending node needs a complete routing information dump    | I        | [BOLT #7][bolt07-sync]                |
-| 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel   | IN       | [BOLT #2][bolt02-open]                |
-| 6/7   | `gossip_queries`                 | More sophisticated gossip control                         | IN       | [BOLT #7][bolt07-query]               |
-| 8/9   | `var_onion_optin`                | Requires/supports variable-length routing onion payloads  | IN9      | [Routing Onion Specification][bolt04] |
-| 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information         | IN       | [BOLT #7][bolt07-query]               |
-| 12/13| `option_static_remotekey`         | Static key for remote output                              | IN       | [BOLT #3](03-transactions.md)         |
-| 14/15 | `payment_secret`                 | Node supports `payment_secret` field                      | IN9      | [Routing Onion Specification][bolt04]   |
-| 16/17 | `basic_mpp`                      | Node can receive basic multi-part payments                | IN9      | [BOLT #4][bolt04-mpp]                 |
+| Bits  | Name                             | Description                                               | Context  | Dependencies      | Link                                  |
+|-------|----------------------------------|-----------------------------------------------------------|----------|-------------------|---------------------------------------|
+| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields   | IN       |                   | [BOLT #2][bolt02-retransmit]          |
+| 3     | `initial_routing_sync`           | Sending node needs a complete routing information dump    | I        |                   | [BOLT #7][bolt07-sync]                |
+| 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel   | IN       |                   | [BOLT #2][bolt02-open]                |
+| 6/7   | `gossip_queries`                 | More sophisticated gossip control                         | IN       |                   | [BOLT #7][bolt07-query]               |
+| 8/9   | `var_onion_optin`                | Requires/supports variable-length routing onion payloads  | IN9      |                   | [Routing Onion Specification][bolt04] |
+| 10/11 | `gossip_queries_ex`              | Gossip queries can include additional information         | IN       | `gossip_queries`  | [BOLT #7][bolt07-query]               |
+| 12/13 | `option_static_remotekey`        | Static key for remote output                              | IN       |                   | [BOLT #3](03-transactions.md)         |
+| 14/15 | `payment_secret`                 | Node supports `payment_secret` field                      | IN9      | `var_onion_optin` | [Routing Onion Specification][bolt04] |
+| 16/17 | `basic_mpp`                      | Node can receive basic multi-part payments                | IN9      | `payment_secret`  | [BOLT #4][bolt04-mpp]                 |
 
 ## Requirements
 
@@ -49,6 +49,7 @@ The origin node:
     unless indicated that it must set the odd feature bit instead.
   * MUST NOT set feature bits it does not support.
   * MUST NOT set feature bits in fields not specified by the table above.
+  * MUST set all transitive feature dependencies.
 
 The requirements for receiving specific bits are defined in the linked sections in the table above.
 The requirements for feature bits that are not defined
@@ -65,6 +66,11 @@ and [BOLT 11](11-payment-encoding.md) invoice contexts, the features as set in
 the [BOLT 11](11-payment-encoding.md) invoice should override those set in the
 `node_announcement`. This keeps things consistent with the unknown features
 behavior as specified in [BOLT 7](07-routing-gossip.md#the-node_announcement-message).
+
+The origin must set all transitive feature dependencies in order to create a
+well-formed feature vector. By validating all known dependencies up front, this
+simplifies logic gated on a single feature bit; the feature's dependencies are
+known to be set, and do not need to be validated at every feature gate.
 
 ![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png "License CC-BY")
 <br>

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -294,17 +294,7 @@ on the amount sent.
 A writer:
   - MUST set the `9` field to a feature vector compliant with the
     [BOLT 9 origin node requirements](09-features.md#requirements).
-  - if `payment_secret` feature is set:
-    - MUST include an `s` field.
-  - otherwise:
-    - MUST NOT include an `s` field.
-  - if the `payment_secret` field is required in the onion:
-    - MUST set the even feature `payment_secret`.
-  - If the final node supports [Basic multi-part payments](04-onion-routing.md#basic-multi-part-payments):
-    - MUST set the `basic_mpp` feature.
-  - Otherwise:
-    - MUST NOT set the `basic_mpp` feature.
-  - MUST set `var_onion_optin` if and only if it supports that feature.
+  - MUST set an `s` field if and only if the `payment_secret` feature is set.
 
 A reader:
   - if the feature vector does not set all known, transitive feature dependencies:

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -292,6 +292,8 @@ on the amount sent.
 ### Requirements
 
 A writer:
+  - MUST set the `9` field to a feature vector compliant with the
+    [BOLT 9 origin node requirements](09-features.md#requirements).
   - if `payment_secret` feature is set:
     - MUST include an `s` field.
   - otherwise:
@@ -300,14 +302,13 @@ A writer:
     - MUST set the even feature `payment_secret`.
   - If the final node supports [Basic multi-part payments](04-onion-routing.md#basic-multi-part-payments):
     - MUST set the `basic_mpp` feature.
-    - MUST set the `payment_secret` feature.
   - Otherwise:
     - MUST NOT set the `basic_mpp` feature.
-  - if it sets the `payment_secret` feature:
-    - MUST set the `var_onion_optin` feature.
   - MUST set `var_onion_optin` if and only if it supports that feature.
 
 A reader:
+  - if the feature vector does not set all known, transitive feature dependencies:
+    - MUST NOT attempt the payment.
   - if the `basic_mpp` feature is offered in the invoice:
     - MAY pay using [Basic multi-part payments](04-onion-routing.md#basic-multi-part-payments).
   - otherwise:

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -571,8 +571,8 @@ Breakdown:
   * `6c6e626332306d0b25fe64570d0e496dbd9f8b0d000dbb44824f751380da37c6dba89b14f6f92047d63f576e304021a00008101820283038404800081018202830384048000810182028303840480810243500c318a1e0a628b34025e8c9019ab6d09b64c2b3c66a693d0dc63194b02481931000` hex of data for signing (prefix + data after separator up to the start of the signature)
   * `399a8b167029fda8564fd2e99912236b0b8017e7d17e416ae17307812c92cf42` hex of SHA256 of the preimage
 
-> ### Please send $30 for coffee beans to the same peer, which supports features 15 and 99, using secret 0x1111111111111111111111111111111111111111111111111111111111111111
-> lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqpqqq4u9s93jtgysm3mrwll70zr697y3mf902hvxwej0v7c62rsltw83ng0pu8w3j230sluc5gxkdmm9dvpy9y6ggtjd2w544mzdrcs42t7sqdkcy8h
+> ### Please send $30 for coffee beans to the same peer, which supports features 9, 15 and 99, using secret 0x1111111111111111111111111111111111111111111111111111111111111111
+> lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqpqsq67gye39hfg3zd8rgc80k32tvy9xk2xunwm5lzexnvpx6fd77en8qaq424dxgt56cag2dpt359k3ssyhetktkpqh24jqnjyw6uqd08sgptq44qu
 
 Breakdown:
 
@@ -588,13 +588,13 @@ Breakdown:
   * `p5`: `data_length` (`p` = 1, `5` = 20; 1 * 32 + 20 == 52)
   * `zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs`: 0x1111111111111111111111111111111111111111111111111111111111111111
 * `9`: features
-  * `q5`: `data_length` (`q` = 0, `5` = 20; 0 * 32 + 20 == 20) 4
-  * `sqqqqqqqqqqqqqqqpqqq`: b1000....00001000000000000000
-* `pqqq4u9s93jtgysm3mrwll70zr697y3mf902hvxwej0v7c62rsltw83ng0pu8w3j230sluc5gxkdmm9dvpy9y6ggtjd2w544mzdrcs42t7sq`: signature
-* `dkcy8h`: Bech32 checksum
+  * `q5`: `data_length` (`q` = 0, `5` = 20; 0 * 32 + 20 == 20)
+  * `sqqqqqqqqqqqqqqqpqsq`: b1000....00001000001000000000
+* `67gye39hfg3zd8rgc8032tvy9xk2xunwm5lzexnvpx6fd77en8qaq424dxgt56cag2dpt359k3ssyhetktkpqh24jqnjyw6uqd08sgp`: signature
+* `tq44qu`: Bech32 checksum
 
 > # Same, but adding invalid unknown feature 100
-> lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqpqqqqu7fz6pjqczdm3jp3qps7xntj2w2mm70e0ckhw3c5xk9p36pvk3sewn7ncaex6uzfq0vtqzy28se6pcwn790vxex7xystzumhg55p6qq9wq7td
+> lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqpqsqq40wa3khl49yue3zsgm26jrepqr2eghqlx86rttutve3ugd05em86nsefzh4pfurpd9ek9w2vp95zxqnfe2u7ckudyahsa52q66tgzcp6t2dyk
 
 Breakdown:
 
@@ -611,9 +611,9 @@ Breakdown:
   * `zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs`: 0x1111111111111111111111111111111111111111111111111111111111111111
 * `9`: features
   * `q4`: `data_length` (`q` = 0, `4` = 21; 0 * 32 + 21 == 21)
-  * `psqqqqqqqqqqqqqqqpqqqq`: b000011000....00001000000000000000
-* `u7fz6pjqczdm3jp3qps7xntj2w2mm70e0ckhw3c5xk9p36pvk3sewn7ncaex6uzfq0vtqzy28se6pcwn790vxex7xystzumhg55p6qq`: signature
-* `9wq7td`: Bech32 checksum
+  * `psqqqqqqqqqqqqqqqpqsqq`: b000011000....00001000001000000000
+* `40wa3khl49yue3zsgm26jrepqr2eghqlx86rttutve3ugd05em86nsefzh4pfurpd9ek9w2vp95zxqnfe2u7ckudyahsa52q66tgzcp`: signature
+* `6t2dyk`: Bech32 checksum
 
 # Authors
 


### PR DESCRIPTION
This PR adds an additional column to our feature table in BOLT 09, enumerating any dependencies that a feature pair has. At the moment, there are 3 such pairs that have dependencies, and more will be added in the near term. The motivation is to offer a concise way to describe these relations, and also simplify how we specify behavior gated by features with dependencies.

Consider the `basic_mpp` feature, which (as of #712) depends on `payment_secret` and transitively depends on `var_onion_optin`. Instead of specifying (or coding) `has(basic_mpp) && has(payment_secret) && has(var_onion_optin)` everywhere we need to gate `basic_mpp`, this allows us to isolate the gate to only `basic_mpp` since the transitive requirements are assumed to be already validated..

An implementation of this validation can be found here: https://github.com/lightningnetwork/lnd/blob/master/feature/deps.go which we are currently using as we build out MPP to simplify our own logic.

The test vectors have also been updated to set the `var_onion_optin` feature when setting a payment secret, as @t-bast points out, the current ones are missing this bit to be fully aligned with the existing spec.