### PR TITLE
Restrict data_loss_protect to init context

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -28,7 +28,7 @@ The Context column decodes as follows:
 
 | Bits  | Name                             | Description                                               | Context  | Link                                  |
 |-------|----------------------------------|-----------------------------------------------------------|----------|---------------------------------------|
-| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields   | IN       | [BOLT #2][bolt02-retransmit]          |
+| 0/1   | `option_data_loss_protect`       | Requires or supports extra `channel_reestablish` fields   | I       | [BOLT #2][bolt02-retransmit]           |
 | 3     | `initial_routing_sync`           | Sending node needs a complete routing information dump    | I        | [BOLT #7][bolt07-sync]                |
 | 4/5   | `option_upfront_shutdown_script` | Commits to a shutdown scriptpubkey when opening channel   | IN       | [BOLT #2][bolt02-open]                |
 | 6/7   | `gossip_queries`                 | More sophisticated gossip control                         | IN       | [BOLT #7][bolt07-query]               |
@@ -65,6 +65,10 @@ and [BOLT 11](11-payment-encoding.md) invoice contexts, the features as set in
 the [BOLT 11](11-payment-encoding.md) invoice should override those set in the
 `node_announcement`. This keeps things consistent with the unknown features
 behavior as specified in [BOLT 7](07-routing-gossip.md#the-node_announcement-message).
+
+Note that feature which only concern connections shouldn't be part of node context.
+A sender should be able to route through a node advertising unknown init feature flags.
+Previously, `option_data_loss_protect` was wrongly in both categories.
 
 ![Creative Commons License](https://i.creativecommons.org/l/by/4.0/88x31.png "License CC-BY")
 <br>


### PR DESCRIPTION
A sender should be able to route through a node even if it doesn't understand init features flag advertised by latter one. For e.g, for a Alice -> Bob -> Dave payment path, Alice should be able to route through Dave even if she doesn't support data_loss_protect as this a connection-only feature.

Right now it's not an issue because everyone implements data_loss_protect (and we may let the feature flag as it is given that's a legacy, pre-flat feature one) but should be aware about this issue if we devise further gentleman policy features a la data_loss_protect, than current contexts don't catch faithfully this class of features. Currently, a node new feature will be seen as unknown by non-upgraded nodes without being able to dissociate between connection-only and packet-processing. Though it lets unsolved how you'll learn about peer supporting without trying to connect first..