### PR TITLE
Avoid stuck channels after fee increase with additional reserve

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -794,11 +794,12 @@ A sending node:
     reserve (see [Updating Fees](#updating-fees-update_fee)).
     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to its commitment
     transaction, its remaining balance doesn't allow it to pay the commitment
-    transaction fee when receiving a future additional non-dust HTLC while maintaining
-    its channel reserve. It is recommended that this "fee spike buffer" can handle
-    twice the current `feerate_per_kw` to ensure predictability between implementations.
+    transaction fee when receiving or sending a future additional non-dust HTLC
+    while maintaining its channel reserve. It is recommended that this "fee spike
+    buffer" can handle twice the current `feerate_per_kw` to ensure predictability
+    between implementations.
   - if it is _not responsible_ for paying the Bitcoin fee:
-    - MUST NOT offer `amount_msat` if, once the remote node adds that HTLC to
+    - SHOULD NOT offer `amount_msat` if, once the remote node adds that HTLC to
     its commitment transaction, it cannot pay the fee for the updated local or
     remote transaction at the current `feerate_per_kw` while maintaining its
     channel reserve.

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -872,9 +872,8 @@ spike buffer" on top of its reserve to accommodate a future fee increase.
 Without this buffer, the node _responsible_ for paying the Bitcoin fee may
 reach a state where it is unable to receive any HTLC while maintaining its
 channel reserve (because of the increased weight of the commitment transaction),
-resulting in an unusable channel.
-See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728) for
-more details.
+resulting in an unusable channel. See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)
+for more details.
 
 ### Removing an HTLC: `update_fulfill_htlc`, `update_fail_htlc`, and `update_fail_malformed_htlc`
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -793,10 +793,10 @@ A sending node:
     transaction at the current `feerate_per_kw` while maintaining its channel
     reserve (see [Updating Fees](#updating-fees-update_fee)).
     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to its commitment
-    transaction, its remaining balance doesn't allow it to pay the fee for a
-    future additional non-dust HTLC at a higher feerate while maintaining its
-    channel reserve ("fee spike buffer"). A buffer of `2*feerate_per_kw` is
-    recommended to ensure predictability.
+    transaction, its remaining balance doesn't allow it to pay the fee to receive a
+    future additional non-dust HTLC while maintaining its channel reserve ("fee
+    spike buffer"). A buffer that expects the current `feerate_per_kw` to potentially
+    double is recommended to ensure predictability between implementations.
   - if it is _not responsible_ for paying the Bitcoin fee:
     - MUST NOT offer `amount_msat` if, once the remote node adds that HTLC to
     its commitment transaction, it cannot pay the fee for the updated local or

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -795,9 +795,8 @@ A sending node:
     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to its commitment
     transaction, its remaining balance doesn't allow it to pay the commitment
     transaction fee when receiving a future additional non-dust HTLC while maintaining
-    its channel reserve ("fee spike buffer"). A buffer that expects the current
-    `feerate_per_kw` to potentially double is recommended to ensure predictability
-    between implementations.
+    its channel reserve. It is recommended that this "fee spike buffer" can handle
+    twice the current `feerate_per_kw` to ensure predictability between implementations.
   - if it is _not responsible_ for paying the Bitcoin fee:
     - MUST NOT offer `amount_msat` if, once the remote node adds that HTLC to
     its commitment transaction, it cannot pay the fee for the updated local or
@@ -872,9 +871,9 @@ bootstrap phase of the network.
 The node _responsible_ for paying the Bitcoin fee should maintain a "fee
 spike buffer" on top of its reserve to accommodate a future fee increase.
 Without this buffer, the node _responsible_ for paying the Bitcoin fee may
-reach a state where it is unable to receive any HTLC while maintaining its
-channel reserve (because of the increased weight of the commitment transaction),
-resulting in an unusable channel. See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)
+reach a state where it is unable to receive any non-dust HTLC while maintaining
+its channel reserve (because of the increased weight of the commitment transaction),
+resulting in a degraded channel. See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)
 for more details.
 
 ### Removing an HTLC: `update_fulfill_htlc`, `update_fail_htlc`, and `update_fail_malformed_htlc`

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -791,12 +791,12 @@ A sending node:
     - MUST NOT offer `amount_msat` if, after adding that HTLC to its commitment
     transaction, it cannot pay the fee for either the local or remote commitment
     transaction at the current `feerate_per_kw` while maintaining its channel
-    reserve (see "Updating Fees").
+    reserve (see [Updating Fees](#updating-fees-update_fee)).
     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to its commitment
     transaction, its remaining balance doesn't allow it to pay the fee for a
-    future additional non-dust HTLC at `N*feerate_per_kw` while maintaining its
-    channel reserve ("fee spike buffer"), where `N` is a parameter chosen by the
-    implementation (`N = 2` is recommended to ensure predictability).
+    future additional non-dust HTLC at a higher feerate while maintaining its
+    channel reserve ("fee spike buffer"). A buffer of `2*feerate_per_kw` is
+    recommended to ensure predictability.
   - if it is _not responsible_ for paying the Bitcoin fee:
     - MUST NOT offer `amount_msat` if, once the remote node adds that HTLC to
     its commitment transaction, it cannot pay the fee for the updated local or
@@ -868,7 +868,7 @@ seconds, and the protocol only supports an expiry in blocks.
 specification; larger amounts are not necessary, nor wise, during the
 bootstrap phase of the network.
 
-The node _responsible_ for paying the Bitcoin fee should maintain a small "fee
+The node _responsible_ for paying the Bitcoin fee should maintain a "fee
 spike buffer" on top of its reserve to accommodate a future fee increase.
 Without this buffer, the node _responsible_ for paying the Bitcoin fee may
 reach a state where it is unable to receive any HTLC while maintaining its

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -872,9 +872,9 @@ bootstrap phase of the network.
 The node _responsible_ for paying the Bitcoin fee should maintain a "fee
 spike buffer" on top of its reserve to accommodate a future fee increase.
 Without this buffer, the node _responsible_ for paying the Bitcoin fee may
-reach a state where it is unable to receive any non-dust HTLC while maintaining
-its channel reserve (because of the increased weight of the commitment transaction),
-resulting in a degraded channel. See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)
+reach a state where it is unable to send or receive any non-dust HTLC while
+maintaining its channel reserve (because of the increased weight of the
+commitment transaction), resulting in a degraded channel. See [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)
 for more details.
 
 ### Removing an HTLC: `update_fulfill_htlc`, `update_fail_htlc`, and `update_fail_malformed_htlc`

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -794,10 +794,11 @@ A sending node:
     reserve (see "Updating Fees").
     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to its commitment
     transaction, its remaining balance doesn't allow it to pay the fee for a
-    future additional non-dust HTLC at `2*feerate_per_kw` while maintaining its
-    channel reserve ("fee spike buffer").
+    future additional non-dust HTLC at `N*feerate_per_kw` while maintaining its
+    channel reserve ("fee spike buffer"), where `N` is a parameter chosen by the
+    implementation (`N = 2` is recommended to ensure predictability).
   - if it is _not responsible_ for paying the Bitcoin fee:
-    - SHOULD NOT offer `amount_msat` if, once the remote node adds that HTLC to
+    - MUST NOT offer `amount_msat` if, once the remote node adds that HTLC to
     its commitment transaction, it cannot pay the fee for the updated local or
     remote transaction at the current `feerate_per_kw` while maintaining its
     channel reserve.
@@ -867,7 +868,7 @@ seconds, and the protocol only supports an expiry in blocks.
 specification; larger amounts are not necessary, nor wise, during the
 bootstrap phase of the network.
 
-The node _responsible_ for paying the Bitcoin fee has to maintain a small "fee
+The node _responsible_ for paying the Bitcoin fee should maintain a small "fee
 spike buffer" on top of its reserve to accommodate a future fee increase.
 Without this buffer, the node _responsible_ for paying the Bitcoin fee may
 reach a state where it is unable to receive any HTLC while maintaining its

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -793,10 +793,11 @@ A sending node:
     transaction at the current `feerate_per_kw` while maintaining its channel
     reserve (see [Updating Fees](#updating-fees-update_fee)).
     - SHOULD NOT offer `amount_msat` if, after adding that HTLC to its commitment
-    transaction, its remaining balance doesn't allow it to pay the fee to receive a
-    future additional non-dust HTLC while maintaining its channel reserve ("fee
-    spike buffer"). A buffer that expects the current `feerate_per_kw` to potentially
-    double is recommended to ensure predictability between implementations.
+    transaction, its remaining balance doesn't allow it to pay the commitment
+    transaction fee when receiving a future additional non-dust HTLC while maintaining
+    its channel reserve ("fee spike buffer"). A buffer that expects the current
+    `feerate_per_kw` to potentially double is recommended to ensure predictability
+    between implementations.
   - if it is _not responsible_ for paying the Bitcoin fee:
     - MUST NOT offer `amount_msat` if, once the remote node adds that HTLC to
     its commitment transaction, it cannot pay the fee for the updated local or


### PR DESCRIPTION
Add an additional "reserve" for funders on top of the real reserve to
avoid getting in a state where the channel is unusable because
of the increased commit tx cost of a new HTLC.

Requirements are only added for the funder sending an HTLC.
Fundee receiving HTLCs may choose to verify that funders apply
this, but it may lead to an unusable UX.

@halseth do you want to chime in since you've been confronted
with this issue on the lnd side?

Fixes #728. (see the issue for a longer discussion)
