### PR TITLE
Remove reference to DER encoding for public keys in compressed format

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -194,7 +194,7 @@ The sending node:
   - MUST ensure `temporary_channel_id` is unique from any other channel ID with the same peer.
   - MUST set `funding_satoshis` to less than 2^24 satoshi.
   - MUST set `push_msat` to equal or less than 1000 * `funding_satoshis`.
-  - MUST set `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, and `delayed_payment_basepoint` to valid DER-encoded, compressed, secp256k1 pubkeys.
+  - MUST set `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, and `delayed_payment_basepoint` to valid secp256k1 pubkeys in compressed format.
   - MUST set `first_per_commitment_point` to the per-commitment point to be used for the initial commitment transaction, derived as specified in [BOLT #3](03-transactions.md#per-commitment-secret-requirements).
   - MUST set `channel_reserve_satoshis` greater than or equal to `dust_limit_satoshis`.
   - MUST set undefined bits in `channel_flags` to 0.
@@ -232,7 +232,7 @@ The receiving node MUST fail the channel if:
   - `max_accepted_htlcs` is greater than 483.
   - it considers `feerate_per_kw` too small for timely processing or unreasonably large.
   - `funding_pubkey`, `revocation_basepoint`, `htlc_basepoint`, `payment_basepoint`, or `delayed_payment_basepoint`
-are not valid DER-encoded compressed secp256k1 pubkeys.
+are not valid secp256k1 pubkeys in compressed format.
   - `dust_limit_satoshis` is greater than `channel_reserve_satoshis`.
   - the funder's amount for the initial commitment transaction is not sufficient for full [fee payment](03-transactions.md#fee-payment).
   - both `to_local` and `to_remote` amounts for the initial commitment transaction are less than or equal to `channel_reserve_satoshis` (see [BOLT 3](03-transactions.md#commitment-transaction-outputs)).

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -62,7 +62,7 @@ Most transaction outputs used here are pay-to-witness-script-hash<sup>[BIP141](h
 
 `2 <pubkey1> <pubkey2> 2 OP_CHECKMULTISIG`
 
-* Where `pubkey1` is the numerically lesser of the two DER-encoded `funding_pubkey` and where `pubkey2` is the numerically greater of the two.
+* Where `pubkey1` is the numerically lesser of the two `funding_pubkey` in compressed format, and where `pubkey2` is the numerically greater of the two.
 
 ## Commitment Transaction
 

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -441,7 +441,7 @@ simply discard its payload.
 The origin node establishes a shared secret with each hop along the route using
 Elliptic-curve Diffie-Hellman between the sender's ephemeral key at that hop and
 the hop's node ID key. The resulting curve point is serialized to the
-DER-compressed representation and hashed using `SHA256`. The hash output is used
+compressed format and hashed using `SHA256`. The hash output is used
 as the 32-byte shared secret.
 
 Elliptic-curve Diffie-Hellman (ECDH) is an operation on an EC private key and

--- a/08-transport.md
+++ b/08-transport.md
@@ -154,7 +154,7 @@ The following functions will also be referenced:
 
   * `ECDH(k, rk)`: performs an Elliptic-Curve Diffie-Hellman operation using
     `k`, which is a valid `secp256k1` private key, and `rk`, which is a valid public key
-      * The returned value is the SHA256 of the DER-compressed format of the
+      * The returned value is the SHA256 of the compressed format of the
 	    generated point.
 
   * `HKDF(salt,ikm)`: a function defined in `RFC 5869`<sup>[3](#reference-3)</sup>,
@@ -202,11 +202,11 @@ As a concluding step, both sides mix the responder's public key into the
 handshake digest:
 
  * The initiating node mixes in the responding node's static public key
-   serialized in Bitcoin's DER-compressed format:
+   serialized in Bitcoin's compressed format:
    * `h = SHA-256(h || rs.pub.serializeCompressed())`
 
  * The responding node mixes in their local static public key serialized in
-   Bitcoin's DER-compressed format:
+   Bitcoin's compressed format:
    * `h = SHA-256(h || ls.pub.serializeCompressed())`
 
 ### Handshake Exchange


### PR DESCRIPTION
ECDSA signatures in Bitcoin are DER-encoded but public keys are not.

The compressed format for public keys is for example standardized in
Sections 2.3.3 and 2.3.4 of

  Standards for Efficient Cryptography, SEC 1: Elliptic Curve
  Cryptography, Certicom Research, Version 2, 2009,
  https://www.secg.org/sec1-v2.pdf