### PR TITLE
Clarify numerical comparison of pubkeys

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -375,3 +375,4 @@ GitHub
 IRC
 bitmasks
 CSPRNG
+lexicographically

--- a/03-transactions.md
+++ b/03-transactions.md
@@ -62,7 +62,7 @@ Most transaction outputs used here are pay-to-witness-script-hash<sup>[BIP141](h
 
 `2 <pubkey1> <pubkey2> 2 OP_CHECKMULTISIG`
 
-* Where `pubkey1` is the numerically lesser of the two `funding_pubkey` in compressed format, and where `pubkey2` is the numerically greater of the two.
+* Where `pubkey1` is the lexicographically lesser of the two `funding_pubkey` in compressed format, and where `pubkey2` is the lexicographically greater of the two.
 
 ## Commitment Transaction
 

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -166,8 +166,8 @@ The origin node:
   as specified in [BOLT #2](02-peer-protocol.md#the-funding_locked-message).
     - Note: the corresponding output MUST be a P2WSH, as described in [BOLT #3](03-transactions.md#funding-transaction-output).
   - MUST set `node_id_1` and `node_id_2` to the public keys of the two nodes
-  operating the channel, such that `node_id_1` is the numerically-lesser of the
-  two DER-encoded keys sorted in ascending numerical order.
+  operating the channel, such that `node_id_1` is the lexicographically-lesser of the
+  two compressed keys sorted in ascending lexicographic order.
   - MUST set `bitcoin_key_1` and `bitcoin_key_2` to `node_id_1` and `node_id_2`'s
   respective `funding_pubkey`s.
   - MUST compute the double-SHA256 hash `h` of the message, beginning at offset


### PR DESCRIPTION
We're using unsigned big-endian comparison.
Thanks to @real-or-random for raising this.