### PR TITLE
Add advisory section for wumbo channels confirmations

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -192,6 +192,10 @@ know this node will accept `funding_satoshis` greater than or equal to 2^24.
 Since it's broadcast in the `node_announcement` message other nodes can use it to identify peers 
 willing to accept large channel even before exchanging the `init` message with them. 
 
+Implementors are advised to provide the means to scale the number of confirmations, tweaking 
+`accept_channel.minimum_depth`, with the size of the funding amount. A rule of thumb is to 
+wait enough blocks until the cumulative block reward exceeds the size of the channel.
+
 #### Requirements
 
 The sending node:

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -192,7 +192,7 @@ know this node will accept `funding_satoshis` greater than or equal to 2^24.
 Since it's broadcast in the `node_announcement` message other nodes can use it to identify peers 
 willing to accept large channel even before exchanging the `init` message with them. 
 
-Implementors are advised to provide the means to scale the number of confirmations, tweaking 
+Implementers are advised to provide the means to scale the number of confirmations, tweaking 
 `accept_channel.minimum_depth`, with the size of the funding amount. A rule of thumb is to 
 wait enough blocks until the cumulative block reward exceeds the size of the channel.
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -193,8 +193,7 @@ Since it's broadcast in the `node_announcement` message other nodes can use it t
 willing to accept large channel even before exchanging the `init` message with them. 
 
 Implementers are advised to provide the means to scale the number of confirmations, tweaking 
-`accept_channel.minimum_depth`, with the size of the funding amount. A rule of thumb is to 
-wait enough blocks until the cumulative block reward largely exceeds the size of the channel.
+`accept_channel.minimum_depth` and `accept_channel.to_self_delay`, with the size of the funding amount.
 
 #### Requirements
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -194,7 +194,7 @@ willing to accept large channel even before exchanging the `init` message with t
 
 Implementers are advised to provide the means to scale the number of confirmations, tweaking 
 `accept_channel.minimum_depth`, with the size of the funding amount. A rule of thumb is to 
-wait enough blocks until the cumulative block reward exceeds the size of the channel.
+wait enough blocks until the cumulative block reward largely exceeds the size of the channel.
 
 #### Requirements
 


### PR DESCRIPTION
This PR is a follow up on #596 adding an advisory section where we suggest implementors to provide the means to scale the number of confirmation along with the channel size. This is a security measure to protect against chain reorgs when opening large channels.