### PR TITLE
Avoid stuck channels after fee increase by dipping into reserve

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -794,9 +794,15 @@ is destined, is described in [BOLT #4](04-onion-routing.md).
 #### Requirements
 
 A sending node:
-  - MUST NOT offer `amount_msat` it cannot pay for in the
-remote commitment transaction at the current `feerate_per_kw` (see "Updating
-Fees") while maintaining its channel reserve.
+  - if it is _responsible_ for paying the Bitcoin fee:
+    - MUST NOT offer `amount_msat` it cannot pay for in the remote commitment
+    transaction at the current `feerate_per_kw` (see "Updating Fees") while
+    maintaining its channel reserve.
+  - if it is _not responsible_ for paying the Bitcoin fee:
+    - MUST NOT offer `amount_msat` if the remote cannot pay the fee for the
+    updated commitment transaction at the current `feerate_per_kw` (see
+    "Updating Fees"). In that case the remote may temporarily dip into its
+    channel reserve to pay the fee, but only for one pending non-dust HTLC.
   - MUST offer `amount_msat` greater than 0.
   - MUST NOT offer `amount_msat` below the receiving node's `htlc_minimum_msat`
   - MUST set `cltv_expiry` less than 500000000.
@@ -862,6 +868,10 @@ seconds, and the protocol only supports an expiry in blocks.
 `amount_msat` is deliberately limited for this version of the
 specification; larger amounts are not necessary, nor wise, during the
 bootstrap phase of the network.
+
+The node _responsible_ for paying the Bitcoin fee should be allowed to dip into
+its channel reserve to accommodate a fee increase, otherwise the channel may end
+up in an unusable state (see [#728](https://github.com/lightningnetwork/lightning-rfc/issues/728)).
 
 ### Removing an HTLC: `update_fulfill_htlc`, `update_fail_htlc`, and `update_fail_malformed_htlc`
 


### PR DESCRIPTION
Allow funders to dip into their channel reserve once to be able to pay the increased commit tx fee for a pending HTLC.

This prevents channels from getting in a state where the channel is unusable because of the increased commit tx cost of a new HTLC.

Fixes #728.  (see the issue for a longer discussion)

This is an alternative to #740. I think it makes sense to dip into the reserve in that case.
Do note that this only fixes the stuck channel issue if the channel reserve is big enough for the fee increase.
At ~3500 sat/kw with a 1% reserve, it means that channels with a capacity bigger than 60 000 sats are safe from getting stuck, but smaller channels may still get stuck.