### PR TITLE
Allow More than one Address of a given type

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -307,7 +307,6 @@ The origin node:
   - MUST NOT create a `type 1` OR `type 2` address descriptor with `port` equal
   to 0.
   - SHOULD ensure `ipv4_addr` AND `ipv6_addr` are routable addresses.
-  - MUST NOT include more than one `address descriptor` of the same type.
   - MUST set `features` according to [BOLT #9](09-features.md#assigned-features-flags)
   - SHOULD set `flen` to the minimum length required to hold the `features`
   bits it sets.


### PR DESCRIPTION
Its not uncommon to be multi-homed with different addresses, so we should probably allow nodes to do this. Also, it seems like this is pretty much universally not actually enforced on the network.