### PR TITLE
RFC: Onion messages (previously "directed messages")

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -56,7 +56,7 @@ The messages are grouped logically into five groups, ordered by the most signifi
   - Setup & Control (types `0`-`31`): messages related to connection setup, control, supported features, and error reporting (described below)
   - Channel (types `32`-`127`): messages used to setup and tear down micropayment channels (described in [BOLT #2](02-peer-protocol.md))
   - Commitment (types `128`-`255`): messages related to updating the current commitment transaction, which includes adding, revoking, and settling HTLCs as well as updating fees and exchanging signatures (described in [BOLT #2](02-peer-protocol.md))
-  - Routing (types `256`-`511`): messages containing node and channel announcements, as well as any active route exploration (described in [BOLT #7](07-routing-gossip.md))
+  - Routing (types `256`-`511`): messages containing node and channel announcements, as well as any active route exploration or messaging (described in [BOLT #7](07-routing-gossip.md))
   - Custom (types `32768`-`65535`): experimental and application-specific messages
 
 The size of the message is required by the transport layer to fit into a 2-byte unsigned int; therefore, the maximum possible size is 65535 bytes.

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -375,31 +375,31 @@ is no legacy format, thus a `bigsize` of 0 means no payload.
 
 1. tlvs: `onionmsg_payload`
 2. types:
-    1. type: 2 (`next_short_channel_id`)
-    2. data:
-        * [`short_channel_id`:`short_channel_id`]
     1. type: 4 (`next_node_id`)
     2. data:
         * [`point`:`node_id`]
-    1. type: 6 (`enctlv`)
+    1. type: 6 (`next_short_channel_id`)
     2. data:
-        * [`...*byte`:`enctlv`]
+        * [`short_channel_id`:`short_channel_id`]
     1. type: 8 (`reply_path`)
     2. data:
         * [`point`:`blinding`]
         * [`...*onionmsg_path`:`path`]
-    1. type: 10 (`blinding`)
+    1. type: 10 (`enctlv`)
+    2. data:
+        * [`...*byte`:`enctlv`]
+    1. type: 12 (`blinding`)
     2. data:
         * [`point`:`blinding`]
 
 1. tlvs: `encmsg_tlvs`
 2. types:
-    1. type: 2 (`next_short_channel_id`)
-    2. data:
-        * [`short_channel_id`:`short_channel_id`]
     1. type: 4 (`next_node_id`)
     2. data:
         * [`point`:`node_id`]
+    1. type: 6 (`next_short_channel_id`)
+    2. data:
+        * [`short_channel_id`:`short_channel_id`]
 
 1. subtype: `onionmsg_path`
 2. data:

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -415,14 +415,16 @@ The writer:
     or `enctlv` indicating the next node.
 - For the the final node's `onionmsg_payload`:
   - if the final node is permitted to reply:
-	- MUST set `reply_path` `blinding` to the initial blinding factor for the `next_node_id`
+    - MUST set `reply_path` `blinding` to the initial blinding factor for the `next_node_id`
     - For the first `reply_path` `path`:
-	  - MUST set `node_id` to the first node in the reply path.
-	- For the remaining `reply_path` `path`:
-	  - MUST set `node_id` to the blinded node id to encrypt the onion hop for.
+      - MUST set `node_id` to the first node in the reply path.
+    - For the remaining `reply_path` `path`:
+      - MUST set `node_id` to the blinded node id to encrypt the onion hop for.
     - Within `reply_path` `path`:
-      - MUST set `enctlv` to the ChaCha20 encryption of a valid `encmsg_tlvs` containing exactly
-	    one of either `next_node_id` or `next_short_channel_id`.
+      - MUST encrypt `enctlv` as detailed in (FIXME: reference to t-bast's blinded path section:
+        `ChaChaPoly-1305` encryption using an all-zero nonce).
+      - MUST set `enctlv` to a valid `encmsg_tlvs` containing exactly one of either
+	    `next_node_id` or `next_short_channel_id`.
   - otherwise:
     - MUST not set `reply_path`.
 

--- a/09-features.md
+++ b/09-features.md
@@ -38,6 +38,8 @@ The Context column decodes as follows:
 | 14/15 | `payment_secret`                 | Node supports `payment_secret` field                      | IN9      | `var_onion_optin` | [Routing Onion Specification][bolt04] |
 | 16/17 | `basic_mpp`                      | Node can receive basic multi-part payments                | IN9      | `payment_secret`  | [BOLT #4][bolt04-mpp]                 |
 | 18/19 | `option_support_large_channel`   | Can create large channels                                 | INC+     |                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
+| 102/103 | `option_onion_messages`        | Can forward onion messages                                | INC-     |                   | [BOLT #7](07-routing-gossip.md#onion-messages) |
+
 
 ## Requirements
 


### PR DESCRIPTION
These are simplified messages, in particular they contain a compact onion for replies.

This could be further enhanced for hornet, if we wanted to go that way.  I've implemented and tested this, including rendevous routing for messages and using the reply.