### PR TITLE
Replace RFC7539 with RFC8439

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -77,7 +77,7 @@ There are a number of conventions adhered to throughout this document:
    algorithm.
  - Elliptic curve: for all computations involving elliptic curves, the Bitcoin
    curve is used, as specified in [`secp256k1`][sec2]
- - Pseudo-random stream: [`ChaCha20`][rfc7539] is used to generate a
+ - Pseudo-random stream: [`ChaCha20`][rfc8439] is used to generate a
    pseudo-random byte stream. For its generation, a fixed null-nonce
    (`0x0000000000000000`) is used, along with a key derived from a shared
    secret and with a `0x00`-byte stream of the desired output size as the
@@ -1199,7 +1199,7 @@ The following is an in-depth trace of an example of error message creation:
 [RFC2104]: https://tools.ietf.org/html/rfc2104
 [fips198]: http://csrc.nist.gov/publications/fips/fips198-1/FIPS-198-1_final.pdf
 [sec2]: http://www.secg.org/sec2-v2.pdf
-[rfc7539]: https://tools.ietf.org/html/rfc7539
+[rfc8439]: https://tools.ietf.org/html/rfc8439
 
 # Authors
 

--- a/08-transport.md
+++ b/08-transport.md
@@ -111,7 +111,7 @@ chosen as the hash function, `secp256k1` as the elliptic curve, and
 `ChaChaPoly-1305` as the AEAD construction.
 
 The composition of `ChaCha20` and `Poly1305` that are used MUST conform to
-`RFC 7539`<sup>[1](#reference-1)</sup>.
+`RFC 8439`<sup>[1](#reference-1)</sup>.
 
 The official protocol name for the Lightning variant of Noise is
 `Noise_XK_secp256k1_ChaChaPoly_SHA256`. The ASCII string representation of
@@ -774,7 +774,7 @@ two key rotations:
 TODO(roasbeef); fin
 
 # References
-1. <a id="reference-1">https://tools.ietf.org/html/rfc7539</a>
+1. <a id="reference-1">https://tools.ietf.org/html/rfc8439</a>
 2. <a id="reference-2">http://noiseprotocol.org/noise.html</a>
 3. <a id="reference-3">https://tools.ietf.org/html/rfc5869</a>
 


### PR DESCRIPTION
7539 is obsoleted by [8439](https://tools.ietf.org/html/rfc8439), as [mentioned in 7539](https://tools.ietf.org/html/rfc7539).