### PR TITLE
BOLT07: prune if oldest channel_update is > 2 weeks old

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -979,7 +979,7 @@ A node:
 #### Requirements
 
 A node:
-  - if a channel's latest `channel_update`s `timestamp` is older than two weeks
+  - if a channel's oldest `channel_update`s `timestamp` is older than two weeks
   (1209600 seconds):
     - MAY prune the channel.
     - MAY ignore the channel.
@@ -996,6 +996,11 @@ both endpoints lose access to their private keys and can neither sign
 unlikely to be part of a computed route, since they would be partitioned off
 from the rest of the network; however, they would remain in the local network
 view would be forwarded to other peers indefinitely.
+
+The oldest `channel_update` is used to prune the channel since both sides need
+to be active in order for the channel to be usable. Doing so prunes channels
+even if one side continues to send fresh `channel_update`s but the other node
+has disappeared.
 
 ## Recommendations for Routing
 


### PR DESCRIPTION
This PR modifies the recommended pruning requirements to use the latest
`channel_update`'s timestamp rather than the oldest. The rationale is that
using the oldest timestamp inadvertently retrains channels for which only
one side of the channel continues to send fresh `channel_update`s.

Consider a new node that makes a channel to y'alls, but then disappears.
The current pruning strategy will keep the channel in its routing table
because y'alls continues to send fresh `channel_update`s, but the channel
is actually unusable because the other party is never online. The new strategy
will remove these low-success nodes/channels from the routing table and
only keep channels where both endpoints have indicated recent activity.

This reduces the number of channels in the public graph by 25% at the time
of writing.

EDIT: updated stats, see [relevant network stats](https://gist.github.com/cfromknecht/6ee9f3beed97878112909771d1c847c2)