### PR TITLE
BOLT 3: fix definition of flip(B) in P.

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -527,7 +527,9 @@ generate_from_seed(seed, I):
     return P
 ```
 
-Where "flip(B)" alternates the B'th least significant bit in the value P.
+Where "flip(B)" alternates the (B mod 8) bit of the (B div 8)
+byte of the value.  So, "flip(0) in e3b0..." is "e2b0...", and
+"flip(10) in "e3b0..." is "e3b4...".
 
 The receiving node:
   - MAY store all previous per-commitment secrets.


### PR DESCRIPTION
It turns out everyone does `P[B / 8] ^= (1 << (P % 8))`, which is not what the spec says to do (it implies you would treat P as a bitstring numbered 255 to 0).

See this stackoverflow question:
	https://stackoverflow.com/questions/49928131/lightning-secret-generation-from-seed

Reported-by: Janus Troelsen @ysangkok (on Twitter)
Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>