### PR TITLE
More conservative `cltv_expiry_delta` recommendations

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -744,7 +744,7 @@ almost arbitrary fees), `S` should be small during normal operation; although,
 given that block times are irregular, empty blocks still occur, fees may vary
 greatly, and the fees cannot be bumped on HTLC transactions, `S=12` should be
 considered a minimum. `S` is also the parameter that may vary the most under
-attack, so a higher value may be desirable when non negligible amounts are at
+attack, so a higher value may be desirable when non-negligible amounts are at
 risk. The grace period `G` can be low (1 or 2), as nodes are required to timeout
 or fulfill as soon as possible; but if `G` is too low it increases the risk of
 unnecessary channel closure due to networking delays.
@@ -766,7 +766,7 @@ There are four values that need be derived:
 4. the minimum `cltv_expiry` accepted for terminal payments: the
    worst case for the terminal node C is `2R+G+S` blocks (as, again, steps
    1-3 above don't apply). The default in [BOLT #11](11-payment-encoding.md) is
-   9, which is less conservative than the 18 that this calculation suggests.
+   18, which matches this calculation.
 
 #### Requirements
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -740,31 +740,33 @@ the longest possible time to redeem it on-chain:
 Thus, the worst case is `3R+2G+2S`, assuming `R` is at least 1. Note that the
 chances of three reorganizations in which the other node wins all of them is
 low for `R` of 2 or more. Since high fees are used (and HTLC spends can use
-almost arbitrary fees), `S` should be small; although, given that block times are
-irregular and empty blocks still occur, `S=2` should be considered a
-minimum. Similarly, the grace period `G` can be low (1 or 2), as nodes are
-required to timeout or fulfill as soon as possible; but if `G` is too low it increases the
-risk of unnecessary channel closure due to networking delays.
+almost arbitrary fees), `S` should be small during normal operation; although,
+given that block times are irregular, empty blocks still occur, fees may vary
+greatly, and the fees cannot be bumped on HTLC transactions, `S=12` should be
+considered a minimum. `S` is also the parameter that may vary the most under
+attack, so a higher value may be desirable when non negligible amounts are at
+risk. The grace period `G` can be low (1 or 2), as nodes are required to timeout
+or fulfill as soon as possible; but if `G` is too low it increases the risk of
+unnecessary channel closure due to networking delays.
 
 There are four values that need be derived:
 
 1. the `cltv_expiry_delta` for channels, `3R+2G+2S`: if in doubt, a
-   `cltv_expiry_delta` of 12 is reasonable (R=2, G=1, S=2).
+   `cltv_expiry_delta` of at least 34 is reasonable (R=2, G=2, S=12).
 
-2. the deadline for offered HTLCs: the deadline after which the channel has to be failed
-   and timed out on-chain. This is `G` blocks after the HTLC's
-   `cltv_expiry`: 1 block is reasonable.
+2. the deadline for offered HTLCs: the deadline after which the channel has to
+   be failed and timed out on-chain. This is `G` blocks after the HTLC's
+   `cltv_expiry`: 1 or 2 blocks is reasonable.
 
-3. the deadline for received HTLCs this node has fulfilled: the deadline after which
-the channel has to be failed and the HTLC fulfilled on-chain before its
-   `cltv_expiry`. See steps 4-7 above, which imply a deadline of `2R+G+S`
-   blocks before `cltv_expiry`: 7 blocks is reasonable.
+3. the deadline for received HTLCs this node has fulfilled: the deadline after
+   which the channel has to be failed and the HTLC fulfilled on-chain before
+   its `cltv_expiry`. See steps 4-7 above, which imply a deadline of `2R+G+S`
+   blocks before `cltv_expiry`: 18 blocks is reasonable.
 
 4. the minimum `cltv_expiry` accepted for terminal payments: the
    worst case for the terminal node C is `2R+G+S` blocks (as, again, steps
-   1-3 above don't apply). The default in
-   [BOLT #11](11-payment-encoding.md) is 9, which is slightly more
-   conservative than the 7 that this calculation suggests.
+   1-3 above don't apply). The default in [BOLT #11](11-payment-encoding.md) is
+   9, which is less conservative than the 18 that this calculation suggests.
 
 #### Requirements
 

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -170,11 +170,10 @@ A writer:
   - MAY include one `x` field.
     - if `x` is included:
       - SHOULD use the minimum `data_length` possible.
-  - MAY include one `c` field.
+  - MUST include one `c` field (`min_final_cltv_expiry`).
     - MUST set `c` to the minimum `cltv_expiry` it will accept for the last
     HTLC in the route.
-    - if `c` is included:
-      - SHOULD use the minimum `data_length` possible.
+    - SHOULD use the minimum `data_length` possible.
   - MAY include one `n` field. (Otherwise performing signature recovery is required)
     - MUST set `n` to the public key used to create the `signature`.
   - MAY include one or more `f` fields.
@@ -212,6 +211,8 @@ A reader:
     - MUST use the `n` field to validate the signature instead of performing signature recovery.
   - if there is a valid `s` field:
     - MUST use that as [`payment_secret`](04-onion-routing.md#tlv_payload-payload-format)
+  - if the `c` field (`min_final_cltv_expiry`) is not provided:
+    - MUST use an expiry delta of at least 18 when making the payment
 
 ### Rationale
 

--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -140,7 +140,7 @@ Currently defined tagged fields are:
 * `n` (19): `data_length` 53. 33-byte public key of the payee node
 * `h` (23): `data_length` 52. 256-bit description of purpose of payment (SHA256). This is used to commit to an associated description that is over 639 bytes, but the transport mechanism for the description in that case is transport specific and not defined here.
 * `x` (6): `data_length` variable. `expiry` time in seconds (big-endian). Default is 3600 (1 hour) if not specified.
-* `c` (24): `data_length` variable. `min_final_cltv_expiry` to use for the last HTLC in the route. Default is 9 if not specified.
+* `c` (24): `data_length` variable. `min_final_cltv_expiry` to use for the last HTLC in the route. Default is 18 if not specified.
 * `f` (9): `data_length` variable, depending on version. Fallback on-chain address: for Bitcoin, this starts with a 5-bit `version` and contains a witness program or P2PKH or P2SH address.
 * `r` (3): `data_length` variable. One or more entries containing extra routing information for a private route; there may be more than one `r` field
    * `pubkey` (264 bits)


### PR DESCRIPTION
Many channels use a value below 6, which is really insecure (there are more than 2k such channels on mainnet).

While less risky, there are more than 7k channels with a value below 12.

This indicates that the spec should probably make the risks a bit more clear to help guide node operators.