### PR TITLE
BOLT 8: add missing MAC check in Act Three

### DIFF
--- a/08-transport.md
+++ b/08-transport.md
@@ -382,6 +382,8 @@ construction, and 16 bytes for a final authenticating tag.
 4. `rs = decryptWithAD(temp_k2, 1, h, c)`
      * At this point, the responder has recovered the static public key of the
        initiator.
+     * If the MAC check in this operation fails, then the responder MUST
+       terminate the connection without any further messages.
 5. `h = SHA-256(h || c)`
 6. `se = ECDH(e.priv, rs)`
      * where `e` is the responder's original ephemeral key


### PR DESCRIPTION
Presumably, this `decryptWithAD` also has a MAC check that can potentially fail, like the other ones. Unlike the other ones, this one does not describe what MUST happen if the MAC check fails.

Maybe it's just a nitpick. Terminating the connection without any further messages seems sensible to me in this case, but I'm not 100% sure if it's necessary, or even if it could be harmful. So don't take my word for it that this is the right behavior: think about it.