### PR TITLE
Add section about private `node_announcement`.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -359,6 +359,16 @@ to be ordered in ascending order, unknown ones can be safely ignored.
 Additional fields beyond `addresses` may also be added in the future—with
 optional padding within `addresses`, if they require certain alignment.
 
+### `node_annoucement` for private channels
+
+while other routing messages (`announcement_signatures`, `channel_announcement` and `channel_update` ) are
+for announcing public channels, `node_announcement` can be used for communication between private channels.
+
+This is useful when a peer wants to accept incoming connection only for a reconnection from the same peer.
+And they want to tell other peer about `addresses` for the reconnection.
+
+NOTE: In this case, since `announcement_signatures` is not exchanged, another peer cannot advertise the channel.
+
 ### Security Considerations for Node Aliases
 
 Node aliases are user-defined and provide a potential avenue for injection


### PR DESCRIPTION
Imagine a following situation.

We are running lightning channel provider service.
When lots of users connect to our service with a private channel. and our node disconnects from the network for some reason, we want to send `channel_reestablish` from our side. Otherwise force-closing all channels will cause lots of on-chain txs.

But for the reconnection, we must know about their public addresses. Their port might be mapped to a different number for inbound and outbound connection so we need a mechanism to tell private nodes to tell their address for inbound connection.

Thus I added section about `node_announcement` for private node.