### PR TITLE
BOLT 4: link to BOLT 1 for tlv_payload format

### DIFF
--- a/01-messaging.md
+++ b/01-messaging.md
@@ -253,7 +253,7 @@ The `features` field MUST be padded to bytes with 0s.
    * [`flen*byte`:`features`]
    * [`init_tlvs`:`tlvs`]
 
-1. tlvs: `init_tlvs`
+1. `tlv_stream`: `init_tlvs`
 2. types:
     1. type: 1 (`networks`)
     2. data:
@@ -672,7 +672,7 @@ The following tests assume that two separate TLV namespaces exist: n1 and n2.
 
 The n1 namespace supports the following TLV types:
 
-1. tlvs: `n1`
+1. `tlv_stream`: `n1`
 2. types:
    1. type: 1 (`tlv1`)
    2. data:
@@ -691,7 +691,7 @@ The n1 namespace supports the following TLV types:
 
 The n2 namespace supports the following TLV types:
 
-1. tlvs: `n2`
+1. `tlv_stream`: `n2`
 2. types:
    1. type: 0 (`tlv1`)
    2. data:

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -125,7 +125,7 @@ the funding transaction and both versions of the commitment transaction.
    * [`byte`:`channel_flags`]
    * [`open_channel_tlvs`:`tlvs`]
 
-1. tlvs: `open_channel_tlvs`
+1. `tlv_stream`: `open_channel_tlvs`
 2. types:
     1. type: 0 (`upfront_shutdown_script`)
     2. data:
@@ -300,7 +300,7 @@ funding transaction and both versions of the commitment transaction.
    * [`point`:`first_per_commitment_point`]
    * [`accept_channel_tlvs`:`tlvs`]
 
-1. tlvs: `accept_channel_tlvs`
+1. `tlv_stream`: `accept_channel_tlvs`
 2. types:
     1. type: 0 (`upfront_shutdown_script`)
     2. data:

--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -246,8 +246,9 @@ parameters may lead to extraneous routing failure.
 ### `tlv_payload` format
 
 This is a more flexible format, which avoids the redundant `short_channel_id` field for the final node. 
+It is formatted according to the Type-Length-Value format defined in [BOLT #1](01-messaging.md#type-length-value-format).
 
-1. tlvs: `tlv_payload`
+1. `tlv_stream`: `tlv_payload`
 2. types:
     1. type: 2 (`amt_to_forward`)
     2. data:

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -598,7 +598,7 @@ Nodes can signal that they support extended gossip queries with the `gossip_quer
     * [`len*byte`:`encoded_short_ids`]
     * [`query_short_channel_ids_tlvs`:`tlvs`]
 
-1. tlvs: `query_short_channel_ids_tlvs`
+1. `tlv_stream`: `query_short_channel_ids_tlvs`
 2. types:
     1. type: 1 (`query_flags`)
     2. data:
@@ -703,7 +703,7 @@ timeouts.  It also causes a natural ratelimiting of queries.
     * [`u32`:`number_of_blocks`]
     * [`query_channel_range_tlvs`:`tlvs`]
 
-1. tlvs: `query_channel_range_tlvs`
+1. `tlv_stream`: `query_channel_range_tlvs`
 2. types:
     1. type: 1 (`query_option`)
     2. data:
@@ -728,7 +728,7 @@ Though it is possible, it would not be very useful to ask for checksums without 
     * [`len*byte`:`encoded_short_ids`]
     * [`reply_channel_range_tlvs`:`tlvs`]
 
-1. tlvs: `reply_channel_range_tlvs`
+1. `tlv_stream`: `reply_channel_range_tlvs`
 2. types:
     1. type: 1 (`timestamps_tlv`)
     2. data:

--- a/tools/extract-formats.py
+++ b/tools/extract-formats.py
@@ -26,7 +26,7 @@ import fileinput
 typeline = re.compile(
     '(1\.|\*) type: (?P<value>[-0-9A-Za-z_|]+) \(`(?P<name>[A-Za-z0-9_]+)`\)( \(`?(?P<option>[^)`]*)`\))?')
 tlvline = re.compile(
-    '(1\.|\*) tlvs: `(?P<name>[A-Za-z0-9_]+)`( \(`?(?P<option>[^)`]*)`\))?')
+    '(1\.|\*) `tlv_stream`: `(?P<name>[A-Za-z0-9_]+)`( \(`?(?P<option>[^)`]*)`\))?')
 subtypeline = re.compile(
     '(1\.|\*) subtype: `(?P<name>[A-Za-z0-9_]+)`( \(`?(?P<option>[^)`]*)`\))?')
 dataline = re.compile(


### PR DESCRIPTION
It might seem a bit redundant, but for me it would have helped to have this link.

I assumed that the payload has the format of `tlv_stream`. Technically, this leads to a small inconsistency though: BOLT 4 says somewhere that "no TLV value can ever be shorter than 2 bytes", but `tlv_stream` can technically consist of zero `tlv_record` elements, resulting in zero bytes. I don't know if it is ever possible for a node to know what to do when it receives a zero-byte payload. It'd have to be some kind of (supposedly useful and well-defined) "default behavior" of the node.

Closes #800