### PR TITLE
Prevent preimage reveal collision while claiming onchain incoming HTLC

### DIFF
--- a/05-onchain.md
+++ b/05-onchain.md
@@ -314,6 +314,7 @@ A local node:
   outgoing HTLC:
     - MUST *resolve* the output by spending it, using the HTLC-success
     transaction.
+    - MUST NOT reveal its own preimage when it's not the final recipient.<sup>[Preimage-Extraction](https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-October/002857.html)</sup>
     - MUST resolve the output of that HTLC-success transaction.
   - otherwise:
     - if the *remote node* is NOT irrevocably committed to the HTLC:


### PR DESCRIPTION
See CVE-2020-26896 for context.