### PR TITLE
Trampoline Routing (2021 edition)

### DIFF
--- a/proposals/trampoline.md
+++ b/proposals/trampoline.md
@@ -1,0 +1,343 @@
+# Trampoline Onion Routing
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [Overview](#overview)
+* [Trampoline onion](#trampoline-onion)
+* [Invoice flow](#invoice-flow)
+* [Privacy](#privacy)
+* [Trampoline MPP](#trampoline-mpp)
+* [Future gossip extensions](#future-gossip-extensions)
+
+## Introduction
+
+As the network grows, more bandwidth and storage will be required to keep an
+up-to-date view of the whole network. Finding a payment path will also require
+more computing power, making it unsustainable for constrained devices.
+
+Constrained devices should only keep a view of a small part of the network and
+leverage trampoline nodes to route payments.
+
+While a thorough analysis has not been made, the current state of the proposal
+should not result in a loss of privacy; on the contrary, it gives more routing
+flexibility and is likely to improve the anonymity set.
+
+## Overview
+
+Nodes that are able to calculate (partial) routes on behalf of other nodes will
+advertise support for the `trampoline_routing` feature. This is an opportunity
+for them to earn more fees than with the default onion routing (payers choose
+to pay a fee premium in exchange for reliable path-finding-as-a-service from
+trampoline nodes).
+
+A payer selects a few trampoline nodes and builds a corresponding trampoline
+onion, very similar to the normal onion; the only difference is that the next
+nodes are identified by `node_id` instead of `short_channel_id` and may not be
+direct peers.
+
+The payer then embeds that trampoline onion in the last `hop_payload` of an
+`onion_packet` destined to the first trampoline node. Computing routes between
+trampoline nodes is then deferred to the trampoline nodes themselves.
+
+A trampoline payment will thus look like this:
+
+```text
+Trampoline route:
+
+Alice ---> Bob ---> Carol ---> Dave
+
+Complete route:
+
+        +--> Irvin --> Iris --+          +--> ... --+            +--> ... --+
+        |                     |          |          |            |          |
+        |                     |          |          |            |          |
+Alice --+                     +--> Bob --+          +--> Carol --+          +--> Dave
+
+<----------------------------------><----------------------><--------------------->
+            (normal payment)            (normal payment)        (normal payment)
+```
+
+Note that this construction still uses onions created by the payer so it doesn't
+sacrifice privacy (in most cases it may even provide a bigger anonymity set).
+
+## Trampoline onion
+
+A trampoline onion uses the same construction as normal payment onions but with
+a smaller size, to allow embedding it inside a normal payment onion.
+
+For example, Alice may want to pay Carol using trampoline. Alice inserts
+trampoline nodes between her and Carol. For this example we use a single
+trampoline (Bob) but Alice may use more than one trampoline.
+
+Alice then finds a route to the first trampoline Bob. The complete route is:
+
+```text
+        +--> Irvin --> Iris --+          +--> ... --+
+        |                     |          |          |
+        |                     |          |          |
+Alice --+                     +--> Bob --+          +--> Carol
+```
+
+Note again that Alice only needs to find a route to Bob (instead of having to
+find a complete route to Carol). She doesn't know what route will be used
+between Bob and Carol: it will be Bob's responsibility to find one that works.
+
+If Alice wants to send 50 000 msat to Carol, the corresponding `update_add_htlc`
+message sent by Alice to Irvin will look like:
+
+```text
+                        update_add_htlc
++---------------------------------------------------------------------------+
+| channel_id: 1x2x3                                                         |
+| htlc_id: 42                                                               |
+| amount_msat: 55000                                                        |
+| cltv_expiry: 1500                                                         |
+| payment_hash: 0xabcd                                                      |
+| onion_routing_packet:                                                     |
+| +-----------------------------------------------------------------------+ |
+| | +--------------------------------------------+----------------------+ | |
+| | | amt_to_forward: 54000                      | normal onion payload | | |
+| | | outgoing_cltv_value: 1450                  | for Irvin            | | |
+| | | short_channel_id: 5x3x7                    |                      | | |
+| | +--------------------------------------------+----------------------+ | |
+| | +--------------------------------------------+----------------------+ | |
+| | | amt_to_forward: 53000                      | normal onion payload | | |
+| | | outgoing_cltv_value: 1400                  | for Iris             | | |
+| | | short_channel_id: 6x3x0                    |                      | | |
+| | +--------------------------------------------+----------------------+ | |
+| | +--------------------------------------------+----------------------+ | |
+| | | amt_to_forward: 53000                      |                      | | |
+| | | outgoing_cltv_value: 1400                  | normal onion payload | | |
+| | | payment_secret: 0x1111                     | for Bob              | | |
+| | | total_amount: 53000                        |                      | | |
+| | | trampoline_onion:                          |                      | | |
+| | | +---------------------------+------------+ |                      | | |
+| | | | amt_to_forward: 50000     | trampoline | |                      | | |
+| | | | outgoing_cltv_value: 1000 | payload    | |                      | | |
+| | | | outgoing_node_id: carol   | for Bob    | |                      | | |
+| | | +---------------------------+------------+ |                      | | |
+| | | +---------------------------+------------+ |                      | | |
+| | | | amt_to_forward: 50000     | trampoline | |                      | | |
+| | | | outgoing_cltv_value: 1000 | payload    | |                      | | |
+| | | | payment_secret: 0x6666    | for Carol  | |                      | | |
+| | | | total_amount: 50000       | (final)    | |                      | | |
+| | | +---------------------------+------------+ |                      | | |
+| | +--------------------------------------------+----------------------+ | |
+| +-----------------------------------------------------------------------+ |
++---------------------------------------------------------------------------+
+```
+
+When Bob receives the trampoline onion, he discovers that the next node is Carol.
+Bob finds a route to Carol, builds a new payment onion and includes the peeled
+trampoline onion in the final payload. This process may repeat with multiple
+trampoline hops until we reach the final recipient.
+
+Here is an example flow of `update_add_htlc` messages received at each hop:
+
+```text
+Alice ------------------> Irvin -------------------------------------> Iris -----------------------------------> Bob -----------------------------------------> John ------------------------------------> Jack ------------------------------------> Carol
+
+                      update_add_htlc                            update_add_htlc                            update_add_htlc                                update_add_htlc                            update_add_htlc                            update_add_htlc               
+               +-------------------------------+          +-------------------------------+          +-----------------------------------+          +-------------------------------+          +-------------------------------+          +-----------------------------------+
+               | channel_id: 1x2x3             |          | channel_id: 5x3x7             |          | channel_id: 6x3x0                 |          | channel_id: 2x8x3             |          | channel_id: 1x3x5             |          | channel_id: 6x5x4                 |
+               | htlc_id: 42                   |          | htlc_id: 21                   |          | htlc_id: 17                       |          | htlc_id: 7                    |          | htlc_id: 15                   |          | htlc_id: 3                        |
+               | amount_msat: 55000            |          | amount_msat: 54000            |          | amount_msat: 53000                |          | amount_msat: 51000            |          | amount_msat: 50500            |          | amount_msat: 50000                |
+               | cltv_expiry: 1500             |          | cltv_expiry: 1450             |          | cltv_expiry: 1400                 |          | cltv_expiry: 1200             |          | cltv_expiry: 1100             |          | cltv_expiry: 1000                 |
+               | payment_hash: 0xabcd          |          | payment_hash: 0xabcd          |          | payment_hash: 0xabcd              |          | payment_hash: 0xabcd          |          | payment_hash: 0xabcd          |          | payment_hash: 0xabcd              |
+               | onion_routing_packet:         |          | onion_routing_packet:         |          | onion_routing_packet:             |          | onion_routing_packet:         |          | onion_routing_packet:         |          | onion_routing_packet:             |
+               | +---------------------------+ |          | +---------------------------+ |          | +-------------------------------+ |          | +---------------------------+ |          | +---------------------------+ |          | +-------------------------------+ |
+               | | amt_to_forward: 54000     | |          | | amt_to_forward: 53000     | |          | | amt_to_forward: 53000         | |          | | amt_to_forward: 50500     | |          | | amt_to_forward: 50000     | |          | | amt_to_forward: 50000         | |
+               | | outgoing_cltv_value: 1450 | |          | | outgoing_cltv_value: 1400 | |          | | outgoing_cltv_value: 1400     | |          | | outgoing_cltv_value: 1100 | |          | | outgoing_cltv_value: 1000 | |          | | outgoing_cltv_value: 1000     | |
+               | | short_channel_id: 5x3x7   | |          | | short_channel_id: 6x3x0   | |          | | payment_secret: 0x1111        | |          | | short_channel_id: 1x3x5   | |          | | short_channel_id: 6x5x4   | |          | | payment_secret: 0x2222        | |
+               | +---------------------------+ |          | +---------------------------+ |          | | total_amount: 53000           | |          | +---------------------------+ |          | +---------------------------+ |          | | total_amount: 50000           | |
+               | |       (encrypted)         | |          | |       (encrypted)         | |          | | trampoline_onion:             | |          | |       (encrypted)         | |          | |       (encrypted)         | |          | | trampoline_onion:             | |
+               | +---------------------------+ |          | +---------------------------+ |          | | +---------------------------+ | |          | +---------------------------+ |          | +---------------------------+ |          | | +---------------------------+ | |
+               +-------------------------------+          +-------------------------------+          | | | amt_to_forward: 50000     | | |          +-------------------------------+          +-------------------------------+          | | | amt_to_forward: 50000     | | |
+                                                                                                     | | | outgoing_cltv_value: 1000 | | |                                                                                                | | | outgoing_cltv_value: 1000 | | |
+                                                                                                     | | | outgoing_node_id: carol   | | |                                                                                                | | | payment_secret: 0x6666    | | |
+                                                                                                     | | +---------------------------+ | |                                                                                                | | | total_amount: 50000       | | |
+                                                                                                     | | |       (encrypted)         | | |                                                                                                | | +---------------------------+ | |
+                                                                                                     | | +---------------------------+ | |                                                                                                | | |           EOF             | | |
+                                                                                                     | +-------------------------------+ |                                                                                                | | +---------------------------+ | |
+                                                                                                     | |             EOF               | |                                                                                                | +-------------------------------+ |
+                                                                                                     | +-------------------------------+ |                                                                                                | |             EOF               | |
+                                                                                                     +-----------------------------------+                                                                                                | +-------------------------------+ |
+                                                                                                                                                                                                                                          +-----------------------------------+
+```
+
+## Invoice flow
+
+Now the question is: how does Alice choose the trampoline nodes to reach Carol?
+
+Similarly to what is done for normal payments, we introduce trampoline hints in
+Bolt 11 invoices. Carol can run a simple breadth-first search to select a few
+trampoline nodes that will be able to relay payments to her and calculates the
+fees and cltv for the corresponding routes. If Carol is accessible via public
+channels, she may not even need to include any trampoline hint.
+
+Each trampoline hint contains only the `node_id` of the trampoline node, a
+`cltv_expiry_delta`, `fee_base_msat` and `fee_proportional_millionths`, for
+example:
+
+```json
+{
+  "trampoline_hints": [
+    {
+      "node_id": "036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2",
+      "cltv_expiry_delta": 288,
+      "fee_base_msat": 5,
+      "fee_proportional_millionths": 300
+    },
+    {
+      "node_id": "025f7117a78150fe2ef97db7cfc83bd57b2e2c0d0dd25eaf467a4a1c2a45ce1486",
+      "cltv_expiry_delta": 432,
+      "fee_base_msat": 8,
+      "fee_proportional_millionths": 250
+    }
+  ]
+}
+```
+
+When Alice wants to pay the invoice, she selects a trampoline node close to her
+(let's call it T1) and a trampoline node from Carol's invoice (let's call it
+T2). If Carol doesn't include any routing hint in the invoice, T2 = Carol.
+
+Alice then simply uses the trampoline route `Alice -> T1 -> T2 -> Carol` and
+creates the corresponding trampoline onion. Alice then finds a route to T1, and
+sends the payment through that route.
+
+```text
+     Alice's neighborhood                                                        Carol's neighborhood
++----------------------------------+                                        +--------------------------------+
+|                                  |                                        |                                |
+|      +-----> T4                  |                                        |       T3 <----- N8 <-----+     |
+|      |                           |                                        |                          |     |
+|      |                           |                                        |                          |     |
+|    Alice -----> N1 -----> T1     |-------> (public network graph) ------->|    T2 -----> N7 -----> Carol   |
+|      |                           |                                        |                                |
+|      |                           |                                        +--------------------------------+
+|      +-----> N2 -----> T5        |
+|                                  |
++----------------------------------+
+```
+
+Alice and Carol both assume connectivity between their respective neighborhoods.
+Note that this assumption is also necessary with the default source-routing
+scheme, so trampoline is not adding any new restrictions.
+
+Alice is completely free to add more intermediate trampoline hops to the route
+to improve privacy (by effectively using longer routes) or to ensure a given
+node is able to witness the payment.
+
+## Privacy
+
+Trampoline routing allows constrained devices to send and receive payments
+without sacrificing privacy.
+
+Such nodes are advised to sync only a small portion of the graph (their local
+neighborhood) and to ensure connectivity to a few distinct trampoline nodes.
+
+This allows them to insert normal hops before the first trampoline node, thus
+protecting their privacy with the same guarantees than normal payments. In the
+example graph from the previous section, T1 cannot know that the payment comes
+from Alice because it only sees an HTLC coming from N1 (especially if Alice is
+using an unannounced channel to N1). When T1 receives the HTLC, it cannot know
+if the next node in the route (T2) is the final destination or not. Similarly,
+T2 cannot know that Carol is the recipient nor that the payment comes from
+Alice (T2 cannot even know that the previous trampoline node was T1).
+
+On top of these guarantees, receivers may use route-blinding or rendezvous to
+hide their exact location. Rendezvous is hard to use with fully source-routed
+payments because if a single channel disappears (or simply does not have enough
+liquidity to relay the payment), it invalidates the whole rendezvous onion.
+Trampoline rendezvous does not have this issue because trampoline routes are
+by design more flexible (only the `node_ids` are fixed, but any route between
+these `node_ids` can be used as long as they fit the fee budget allocated to
+each trampoline hop).
+
+## Trampoline MPP
+
+Trampoline routing combines nicely with multi-part payments. When multi-part
+payment is used, we can let trampoline nodes combine all the incoming partial
+payments before forwarding. Once the totality of the payment is received, the
+trampoline node can choose the most efficient way to re-split it to reach the
+next trampoline node.
+
+For example, Alice could split a payment in 3 parts to reach a trampoline node,
+which would then split it in only 2 parts to reach the destination (we use a
+single hop between trampoline nodes for simplicity here, but any number of
+intermediate nodes may be used):
+
+```text
+                                                     HTLC(1500 msat, 600112 cltv)
+                                                    +---------------------------+
+                                                    | amount_fwd: 1500 msat     |
+                                                    | expiry: 600112            |
+            HTLC(1560 msat, 600124 cltv)            | payment_secret: aaaaa     |
+             +-----------------------+              | total_amount: 2800 msat   |
+             | amount_fwd: 1500 msat |              | trampoline_onion:         |                                                                  HTLC(1100 msat, 600000 cltv)
+             | expiry: 600112        |              | +-----------------------+ |                                                                 +-----------------------------+
+        +--> | channel_id: 3         | ---> I1 ---> | | amount_fwd: 2500 msat | | --+                                                             | amount_fwd: 1100 msat       |
+        |    |-----------------------|              | | expiry: 600000        | |   |                                                             | expiry: 600000              |
+        |    |     (encrypted)       |              | | node_id: Bob          | |   |                                                             | payment_secret: xxxxx       |
+        |    +-----------------------+              | +-----------------------+ |   |                     HTLC(1150 msat, 600080 cltv)            | total_amount: 2500 msat     |
+        |                                           | |      (encrypted)      | |   |                      +-----------------------+              | trampoline_onion:           |
+        |                                           | +-----------------------+ |   |                      | amount_fwd: 1100 msat |              | +-------------------------+ |
+        |                                           +---------------------------+   |                      | expiry: 600000        |              | | amount_fwd: 2500 msat   | |
+        |                                           |             EOF           |   |                 +--> | channel_id: 561       | ---> I4 ---> | | expiry: 600000          | | --+
+        |                                           +---------------------------+   |                 |    |-----------------------|              | | total_amount: 2500 msat | |   |
+        |                                            HTLC(800 msat, 600112 cltv)    |                 |    |     (encrypted)       |              | | payment_secret: yyyyy   | |   |
+        |                                           +---------------------------+   |                 |    +-----------------------+              | +-------------------------+ |   |
+        |                                           | amount_fwd: 800 msat      |   |                 |                                           | |         EOF             | |   |
+        |                                           | expiry: 600112            |   |                 |                                           | +-------------------------+ |   |
+        |   HTLC(820 msat, 600130 cltv)             | payment_secret: aaaaa     |   |                 |                                           +-----------------------------+   |
+        |    +-----------------------+              | total_amount: 2800 msat   |   |                 |                                           |             EOF             |   |
+        |    | amount_fwd: 800 msat  |              | trampoline_onion:         |   |                 |                                           +-----------------------------+   |
+        |    | expiry: 600112        |              | +-----------------------+ |   |                 |                                                                             |
+Alice --+--> | channel_id: 5         | ---> I2 ---> | | amount_fwd: 2500 msat | | --+--> Trampoline --+                                                                             +--> Bob
+        |    |-----------------------|              | | expiry: 600000        | |   |  (fee 170 msat) |                                            HTLC(1400 msat, 600000 cltv)     |
+        |    |     (encrypted)       |              | | node_id: Bob          | |   |    (delta 32)   |                                           +-----------------------------+   |
+        |    +-----------------------+              | +-----------------------+ |   |                 |                                           | amount_fwd: 1400 msat       |   |
+        |                                           | |      (encrypted)      | |   |                 |                                           | expiry: 600000              |   |
+        |                                           | +-----------------------+ |   |                 |                                           | payment_secret: xxxxx       |   |
+        |                                           +---------------------------+   |                 |   HTLC(1480 msat, 600065 cltv)            | total_amount: 2500 msat     |   |
+        |                                           |             EOF           |   |                 |    +-----------------------+              | trampoline_onion:           |   |
+        |                                           +---------------------------+   |                 |    | amount_fwd: 1400 msat |              | +-------------------------+ |   |
+        |                                            HTLC(500 msat, 600112 cltv)    |                 |    | expiry: 600000        |              | | amount_fwd: 2500 msat   | |   |
+        |                                           +---------------------------+   |                 +--> | channel_id: 1105      | ---> I5 ---> | | expiry: 600000          | | --+
+        |                                           | amount_fwd: 500 msat      |   |                      |-----------------------|              | | total_amount: 2500 msat | |
+        |                                           | expiry: 600112            |   |                      |     (encrypted)       |              | | payment_secret: yyyyy   | |
+        |   HTLC(510 msat, 600120 cltv)             | payment_secret: aaaaa     |   |                      +-----------------------+              | +-------------------------+ |
+        |    +-----------------------+              | total_amount: 2800 msat   |   |                                                             | |         EOF             | |
+        |    | amount_fwd: 500 msat  |              | trampoline_onion:         |   |                                                             | +-------------------------+ |
+        |    | expiry: 600112        |              | +-----------------------+ |   |                                                             +-----------------------------+
+        +--> | channel_id: 7         | ---> I3 ---> | | amount_fwd: 2500 msat | | --+                                                             |             EOF             |
+             |-----------------------|              | | expiry: 600000        | |                                                                 +-----------------------------+
+             |     (encrypted)       |              | | node_id: Bob          | |
+             +-----------------------+              | +-----------------------+ |
+                                                    | |      (encrypted)      | |
+                                                    | +-----------------------+ |
+                                                    +---------------------------+
+                                                    |             EOF           |
+                                                    +---------------------------+
+```
+
+## Future gossip extensions
+
+With the current gossip mechanisms, some bandwidth will be unnecessarily wasted
+when constrained nodes sync their local neighborhood, because they have no way
+of asking for `channel_update`s within a given distance boundary nor telling
+their peers to *not* relay some updates to them.
+
+That can be easily addressed in the future with new Bolt 7 gossip queries, but
+is not mandatory to the deployment of trampoline routing.
+
+Two mechanisms in particular would be useful:
+
+* `channel_update` filters: constrained nodes can ask their peers to discard
+  updates coming from nodes that are further than N hops instead of relaying
+  them.
+* distance-based gossip queries: constrained nodes can ask their peers for all
+  updates from nodes that are at most N hops far, and combine that with the
+  current gossip query tricks to avoid replaying updates they already have.

--- a/trampoline.md
+++ b/trampoline.md
@@ -1,0 +1,185 @@
+# Trampoline Onion Routing
+
+This file contains all the low-level details about the proposal in one place to
+simplify reviewers life.
+
+Once we make progress towards standardization, we will move these sections and
+include them in the existing bolts.
+
+## Table of Contents
+
+* [Features](#features)
+* [Packet Structure](#packet-structure)
+  * [Trampoline Onion](#trampoline-onion)
+  * [Paying via trampoline nodes](#paying-via-trampoline-nodes)
+  * [Invoice trampoline hints](#invoice-trampoline-hints)
+  * [Failure messages](#failure-messages)
+* [Multi-Part Trampoline](#multi-part-trampoline)
+
+## Features
+
+Trampoline routing uses the following `features` flags:
+
+| Bits  | Name                 | Description                           | Context  | Dependencies | Link |
+|-------|----------------------|---------------------------------------|----------|--------------|------|
+| 26/27 | `trampoline_routing` | This node supports trampoline routing | IN9      | `basic_mpp`  |      |
+
+## Packet Structure
+
+### Trampoline Onion
+
+The trampoline onion is a variable-size tlv field with the following structure:
+
+1. type: 12 (`trampoline_onion_packet`)
+2. data:
+   * [`byte`:`version`]
+   * [`point`:`public_key`]
+   * [`...*byte`:`hop_payloads`]
+   * [`32*byte`:`hmac`]
+
+It has exactly the same format as the `onion_packet` with a smaller `hop_payloads`.
+Unlike the size of the `onion_packet`, the size of the `trampoline_onion_packet`
+does not need to be fixed because it cannot be observed on the wire (since it is
+always included inside a fixed-size `onion_packet`). Senders are free to choose
+the size they want to allocate to the `trampoline_onion_packet` (it's a trade-off
+between how much data needs to be transmitted to trampoline nodes and how much
+space is left for trampoline nodes to route between themselves).
+
+Trampoline `hop_payload`s may contain the following fields:
+
+1. tlvs: `trampoline_payload`
+2. types:
+    * type: 2 (`amt_to_forward`)
+    * data:
+        * [`tu64`:`amt_to_forward`]
+    * type: 4 (`outgoing_cltv_value`)
+    * data:
+        * [`tu32`:`outgoing_cltv_value`]
+    * type: 8 (`payment_data`)
+        * [`32*byte`:`payment_secret`]
+        * [`tu64`:`total_msat`]
+    * type: 10 (`outgoing_node_id`)
+    * data:
+        * [`point`:`outgoing_node_id`]
+
+### Paying via trampoline nodes
+
+A recipient can signal support for receiving trampoline payments by setting the
+`trampoline_routing` feature bit in invoices. A sender that wants to pay that
+invoice may then rely on trampoline nodes to relay the payment by adding a
+`trampoline_onion_packet` in the `hop_payload` of the _last_ hop of a normal
+`onion_packet`:
+
+1. type: `onion_packet`
+2. data:
+   * [`byte`:`version`]
+   * [`point`:`public_key`]
+   * [`n1*byte`:`hop_payload`] (normal hop payload)
+   * [`n2*byte`:`hop_payload`] (normal hop payload)
+   * ...
+   * [`nn*byte`:`hop_payload`] (hop payload containing a `trampoline_onion_packet`)
+   * `filler`
+   * [`32*byte`:`hmac`]
+
+### Invoice trampoline hints
+
+A new Bolt 11 tagged field is defined:
+
+* `t` (11): `data_length` variable. One or more entries containing trampoline
+  routing information. There may be more than one `t` field.
+  * `trampoline_node_id` (264 bits)
+  * `fee_base_msat` (32 bits, big-endian)
+  * `fee_proportional_millionths` (32 bits, big-endian)
+  * `cltv_expiry_delta` (16 bits, big-endian)
+
+### Failure messages
+
+The following new `failure_code` is defined:
+
+1. type: NODE|24 (`trampoline_fee_expiry_insufficient`)
+2. data:
+   * [`u32`:`fee_base_msat`]
+   * [`u32`:`fee_proportional_millionths`]
+   * [`u16`:`cltv_expiry_delta`]
+
+The fee amount or cltv value was below that required by the trampoline node to
+forward to the next trampoline node.
+
+Note that when returning errors, trampoline nodes apply two layers of onion
+encryption: one with the shared secret from the trampoline onion, then a second
+one with the shared secret from the normal onion. This ensures that previous
+trampoline nodes cannot decrypt the contents of the error and lets the sender
+figure out which trampoline node the error comes from.
+
+### Requirements
+
+A sending node:
+
+* If the invoice doesn't support the `trampoline_routing` feature:
+  * MUST NOT use trampoline routing to pay that invoice
+* MUST ensure that each hop in the `trampoline_onion_packet` supports `trampoline_routing`
+* MUST encrypt the `trampoline_onion_packet` with the same construction as `onion_packet`
+* MUST use a different `session_key` for the `trampoline_onion_packet` and the `onion_packet`
+* MAY include additional tlv types in `trampoline_payload`s
+* MUST include the `trampoline_onion_packet` tlv in the _last_ hop's payload of the `onion_packet`
+
+When processing a `trampoline_onion_packet`, a receiving node:
+
+* If it doesn't support `trampoline_routing`:
+  * MUST report a route failure to the origin node
+* MUST process the `trampoline_onion_packet` as an `onion_packet`
+* If it encounters an unknown _even_ tlv type inside the `trampoline_onion_packet`:
+  * MUST report a route failure to the origin node
+* If it doesn't have enough data to locate the next hop:
+  * MUST report a route failure to the origin node
+* MUST compute a route to the next trampoline hop:
+  * If it cannot find a route that satisfies fees or cltv requirements:
+    * MUST report a route failure to the origin node using the `trampoline_fee_expiry_insufficient` error
+  * Otherwise:
+    * MUST include the peeled `trampoline_onion_packet` in the last `hop_payload`
+* MUST return errors as specified in Bolt 4's [error handling section](https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#returning-errors)
+* MUST apply two layers of onion encryption when returning errors, first with
+  the trampoline onion shared secret, then with the normal onion shared secret
+
+### Rationale
+
+This construction allows nodes with an incomplete view of the network to
+delegate the construction of parts of the route to trampoline nodes.
+
+The origin node only needs to select a set of trampoline nodes and to know a
+route to the first trampoline node. Each trampoline node is responsible for
+finding its own route to the next trampoline node. Trampoline nodes only learn
+the previous node (which may or may not be a trampoline node) and the next
+trampoline node, which guarantees the same anonymity as normal payments.
+
+The `trampoline_onion_packet` has a variable size to allow implementations to
+choose their own trade-off between flexibility and privacy. It's recommended to
+add trailing filler data to the `trampoline_onion_packet` when using a small
+number of hops. It uses the same onion construction as the `onion_packet`.
+
+Trampoline nodes are free to use as many hops as they want between themselves
+as long as they are able to create a route that satisfies the `cltv` and `fees`
+requirements contained in the onion. This includes doing a single-hop payment
+to the next trampoline node if they have suitable channels available.
+
+## Multi-Part Trampoline
+
+Trampoline routing combines nicely with multi-part payments. When multi-part
+payment is used, we can let trampoline nodes combine all the incoming partial
+payments before forwarding. Once the totality of the payment is received, the
+trampoline node can choose the most efficient way to re-split it to reach the
+next trampoline node.
+
+### Requirements
+
+A sending node:
+
+* MUST include the final recipient's `payment_secret` (e.g. from a Bolt 11
+  invoice) in the last trampoline onion payload
+* MUST generate a different `payment_secret` to use in the outer onion
+
+A processing node:
+
+* MAY aggregate the incoming multi-part payment before forwarding
+* If it uses a multi-part payment to forward to the next node:
+  * MUST generate a different `payment_secret` to use in the outer onion


### PR DESCRIPTION
This proposal allows nodes running on constrained devices to sync only a small portion of the network and leverage trampoline nodes to calculate the missing parts of the payment route while providing the same privacy as fully source-routed payments.

The main idea is to use layered onions: a normal onion contains a smaller onion for the last hop of the route, and that smaller onion contains routing information about the next trampoline hop.

This PR is split in two files. Reviewers should start with `proposals/trampoline.md`, where concepts and designs are presented at a higher level. This document lets reviewers see the big picture and how all the pieces work together. It also contains pretty detailed examples that should give reviewers some intuition about the subtle low-level details.

Then reviewers can move on to `trampoline.md` which contains an aggregate of the spec sections that will be incorporated into existing bolts. This is following the usual spec format, and is where we'll work on the nitty-gritty details.

This PR supercedes #654 based on what we learnt after 1 year running trampoline in production in [Phoenix](https://phoenix.acinq.co/) and many discussions with @ecdsa while Electrum worked on their own trampoline implementation. The important changes are:

* the trampoline onion is now variable-size: it's much more flexible and has no privacy downside since it's not observable at the network layer (which is the reason why the outer onion is constant size)
* trampoline doesn't need any new gossip mechanism and instead relies on the recipient doing a small amount of work to include trampoline hints in invoices
