### PR TITLE
Use TLV in Bolt 11 invoices

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -150,9 +150,27 @@ Currently defined tagged fields are:
    * `fee_base_msat` (32 bits, big-endian)
    * `fee_proportional_millionths` (32 bits, big-endian)
    * `cltv_expiry_delta` (16 bits, big-endian)
+* `t` (11): `data_length` variable. An `invoice_tlvs` TLV stream.
 * `9` (5): `data_length` variable. One or more 5-bit values containing features
   supported or required for receiving this payment.
   See [Feature Bits](#feature-bits).
+
+The `t` field is formatted according to the Type-Length-Value format defined
+in [BOLT #1](01-messaging.md#type-length-value-format). It uses the following
+types:
+
+1. type: `trampoline_hint`
+2. data:
+   * [`point`:`trampoline_node_id`]
+   * [`bigsize`:`fee_base_msat`]
+   * [`bigsize`:`fee_proportional_millionths`]
+   * [`u16`:`cltv_expiry_delta`]
+
+1. `tlv_stream`: `invoice_tlvs`
+2. types:
+    1. type: 1 (`trampoline_hints`)
+    2. data:
+        * [`...*trampoline_hint`:`trampoline_hints`]
 
 ### Requirements
 


### PR DESCRIPTION
TLV provides more flexibility to add new fields and replace old ones without breaking backwards-compatibility (at the cost of bigger invoices).

This PR is early stage, and needs your input to progress. While the goal is quite clear the design space is quite large. I believe our first goal is to move the routing hints to the tlv format, but there are multiple ways we can do that.

## Option 1

A `routing_hint` TLV is an array of arrays of `<pubkey>|<short_channel_id>|<fee_base_msat>|<fee_proportional_millionths>|<cltv_expiry_delta>`.

This is mostly what we have now, but expressed in tlv. If we do that, we don't have much flexibility to change the content of a single routing hint. If we want to add the node's features for example, we need to duplicate this in a `routing_hint_v2` that adds features.

## Option 2

Every field becomes a tlv, making everything replaceable by another tlv in the future.
A `routing_hint` would be an array of `tlv_stream`s, and inside each `tlv_stream` we could find some of the following tlvs:

- `pubkey`
- `short_channel_id`
- `fee_base_msat`
- `fee_proportional_millionths`
- `cltv_expiry_delta`
- `features`
- etc

This gives a lot of flexibility, but takes more space as each field will be prefixed by its length.

## Options N

A lot of other options are possible, where we decide that some fields are grouped together in a single TLV (for example `fee_base_msat` + `fee_proportional_millionths` + `cltv_expiry_delta` could be in the same tlv field) and others are separated.