### PR TITLE
Bolt 11: add distinct HRP prefix for Bitcoin signet

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -48,7 +48,8 @@ A reader:
 
 The human-readable part of a Lightning invoice consists of two sections:
 1. `prefix`: `ln` + BIP-0173 currency prefix (e.g. `lnbc` for Bitcoin mainnet,
-   `lntb` for Bitcoin testnet, and `lnbcrt` for Bitcoin regtest)
+   `lntb` for Bitcoin testnet, `lntbs` for Bitcoin signet, and `lnbcrt` for
+   Bitcoin regtest)
 1. `amount`: optional number in that currency, followed by an optional
    `multiplier` letter. The unit encoded here is the 'social' convention of a payment unit -- in the case of Bitcoin the unit is 'bitcoin' NOT satoshis.
 


### PR DESCRIPTION
Judging from the comment
https://github.com/bitcoin/bitcoin/pull/18267/files#r491150895 in the
Signet PR all test networks should have the same bech32_hrp prefix (even
regtest). That's why `tb` was chosen for Signet as well.
This is not optimal for LN as invoices shouldn't be vague in
what network they were issued for.
Therefore we add the explicit prefix `lntbs` for Signet invoices.

This PR was motivated by this comment: https://github.com/lightningnetwork/lnd/pull/5025#discussion_r575984300

The actual value (`lntbs`? `lnbcsn`? `lnsn`?) is open for discussion IMO.

For reference, CL already wrote some code to handle the current issue of testnet and signet using the same prefix: https://github.com/ElementsProject/lightning/blob/030a19a8af989db38d3c547a81faff5b1e11608d/common/bolt11.c#L613