### PR TITLE
Update closing_signed fee requirement

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -566,12 +566,13 @@ The funding node:
     - SHOULD send a `closing_signed` message.
 
 The sending node:
-  - MUST set `fee_satoshis` less than or equal to the
- base fee of the final commitment transaction, as calculated in [BOLT #3](03-transactions.md#fee-calculation).
-  - SHOULD set the initial `fee_satoshis` according to its
- estimate of cost of inclusion in a block.
-  - MUST set `signature` to the Bitcoin signature of the close
- transaction, as specified in [BOLT #3](03-transactions.md#closing-transaction).
+  - If the channel does not use `option_anchor_outputs`:
+    - MUST set `fee_satoshis` less than or equal to the base fee of the final
+    commitment transaction, as calculated in [BOLT #3](03-transactions.md#fee-calculation).
+  - SHOULD set the initial `fee_satoshis` according to its estimate of cost of
+  inclusion in a block.
+  - MUST set `signature` to the Bitcoin signature of the close transaction,
+  as specified in [BOLT #3](03-transactions.md#closing-transaction).
 
 The receiving node:
   - if the `signature` is not valid for either variant of closing transaction
@@ -580,9 +581,9 @@ The receiving node:
   - if `fee_satoshis` is equal to its previously sent `fee_satoshis`:
     - SHOULD sign and broadcast the final closing transaction.
     - MAY close the connection.
-  - otherwise, if `fee_satoshis` is greater than
-the base fee of the final commitment transaction as calculated in
-[BOLT #3](03-transactions.md#fee-calculation):
+  - otherwise, if `fee_satoshis` is greater than the base fee of the final
+  commitment transaction as calculated in [BOLT #3](03-transactions.md#fee-calculation)
+  and the channel does not use `option_anchor_outputs`:
     - MUST fail the connection.
   - if `fee_satoshis` is not strictly
 between its last-sent `fee_satoshis` and its previously-received

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -579,9 +579,6 @@ The funding node:
     - SHOULD send a `closing_signed` message.
 
 The sending node:
-  - If the channel does not use `option_anchor_outputs`:
-    - MUST set `fee_satoshis` less than or equal to the base fee of the final
-    commitment transaction, as calculated in [BOLT #3](03-transactions.md#fee-calculation).
   - SHOULD set the initial `fee_satoshis` according to its estimate of cost of
   inclusion in a block.
   - SHOULD set `fee_range` according to the minimum and maximum fees it is
@@ -603,10 +600,6 @@ The receiving node:
     - SHOULD use `fee_satoshis` to sign and broadcast the final closing transaction
     - SHOULD reply with a `closing_signed` with the same `fee_satoshis` value if it is different from its previously sent `fee_satoshis`
     - MAY close the connection.
-  - otherwise, if `fee_satoshis` is greater than the base fee of the final
-  commitment transaction as calculated in [BOLT #3](03-transactions.md#fee-calculation)
-  and the channel does not use `option_anchor_outputs`:
-    - MUST fail the connection.
   - if the message contains a `fee_range`:
     - if there is no overlap between that and its own `fee_range`:
       - SHOULD send a `warning`

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -553,11 +553,24 @@ the other node then replies similarly, using a fee it thinks is fair.  This
 exchange continues until both agree on the same fee or when one side fails
 the channel.
 
+In the modern method, the funder sends its permissable fee range, and the
+non-funder has to pick a fee in this range. If it chooses the same value,
+negotiation is complete after two messages, otherwise the funder will reply
+with the same value (completing after three messages).
+
 1. type: 39 (`closing_signed`)
 2. data:
    * [`channel_id`:`channel_id`]
    * [`u64`:`fee_satoshis`]
    * [`signature`:`signature`]
+   * [`closing_signed_tlvs`:`tlvs`]
+
+1. `tlv_stream`: `closing_signed_tlvs`
+2. types:
+    1. type: 1 (`fee_range`)
+    2. data:
+        * [`u64`:`min_fee_satoshis`]
+        * [`u64`:`max_fee_satoshis`]
 
 #### Requirements
 
@@ -571,6 +584,11 @@ The sending node:
     commitment transaction, as calculated in [BOLT #3](03-transactions.md#fee-calculation).
   - SHOULD set the initial `fee_satoshis` according to its estimate of cost of
   inclusion in a block.
+  - SHOULD set `fee_range` according to the minimum and maximum fees it is
+  prepared to pay for a close transaction.
+  - if it is not the funder:
+    - SHOULD set `max_fee_satoshis` to at least the `max_fee_satoshis` received
+	  - SHOULD set `min_fee_satoshis` to a fairly low value
   - MUST set `signature` to the Bitcoin signature of the close transaction,
   as specified in [BOLT #3](03-transactions.md#closing-transaction).
 
@@ -581,30 +599,53 @@ The receiving node:
   - if `fee_satoshis` is equal to its previously sent `fee_satoshis`:
     - SHOULD sign and broadcast the final closing transaction.
     - MAY close the connection.
+  - if `fee_satoshis` matches its previously sent `fee_range`:
+    - SHOULD use `fee_satoshis` to sign and broadcast the final closing transaction
+    - SHOULD reply with a `closing_signed` with the same `fee_satoshis` value if it is different from its previously sent `fee_satoshis`
+    - MAY close the connection.
   - otherwise, if `fee_satoshis` is greater than the base fee of the final
   commitment transaction as calculated in [BOLT #3](03-transactions.md#fee-calculation)
   and the channel does not use `option_anchor_outputs`:
     - MUST fail the connection.
-  - if `fee_satoshis` is not strictly
-between its last-sent `fee_satoshis` and its previously-received
-`fee_satoshis`, UNLESS it has since reconnected:
+  - if the message contains a `fee_range`:
+    - if there is no overlap between that and its own `fee_range`:
+      - SHOULD fail the connection
+    - otherwise:
+      - if it is the funder:
+        - if `fee_satoshis` is not in the overlap between the sent and received `fee_range`:
+          - SHOULD fail the connection
+        - otherwise:
+          - MUST reply with the same `fee_satoshis`.
+      - otherwise (it is not the funder):
+        - if it has already sent a `closing_signed`:
+          - if `fee_satoshis` is not the same as the value it sent:
+            - SHOULD fail the connection.
+        - otherwise:
+          - MUST propose a `fee_satoshis` in the overlap between received and (about-to-be) sent `fee_range`.
+  - otherwise, if `fee_satoshis` is not strictly between its last-sent `fee_satoshis`
+  and its previously-received `fee_satoshis`, UNLESS it has since reconnected:
     - SHOULD fail the connection.
-  - if the receiver agrees with the fee:
+  - otherwise, if the receiver agrees with the fee:
     - SHOULD reply with a `closing_signed` with the same `fee_satoshis` value.
   - otherwise:
     - MUST propose a value "strictly between" the received `fee_satoshis`
-  and its previously-sent `fee_satoshis`.
+    and its previously-sent `fee_satoshis`.
 
 #### Rationale
 
-The "strictly between" requirement ensures that forward
-progress is made, even if only by a single satoshi at a time. To avoid
-keeping state and to handle the corner case, where fees have shifted
+When `fee_range` is not provided, the "strictly between" requirement ensures
+that forward progress is made, even if only by a single satoshi at a time.
+To avoid keeping state and to handle the corner case, where fees have shifted
 between disconnection and reconnection, negotiation restarts on reconnection.
 
 Note there is limited risk if the closing transaction is
 delayed, but it will be broadcast very soon; so there is usually no
 reason to pay a premium for rapid processing.
+
+Note that the non-funder is not paying the fee, so there is no reason for it
+to have a maximum feerate. It may want a minimum feerate, however, to ensure
+that the transaction propagates. It can always use CPFP later to speed up
+confirmation if necessary, so that minimum should be low.
 
 ## Normal Operation
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -587,7 +587,7 @@ The sending node:
     - MUST fail the channel
   - if it is not the funder:
     - SHOULD set `max_fee_satoshis` to at least the `max_fee_satoshis` received
-	  - SHOULD set `min_fee_satoshis` to a fairly low value
+    - SHOULD set `min_fee_satoshis` to a fairly low value
   - MUST set `signature` to the Bitcoin signature of the close transaction,
   as specified in [BOLT #3](03-transactions.md#closing-transaction).
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -583,6 +583,8 @@ The sending node:
   inclusion in a block.
   - SHOULD set `fee_range` according to the minimum and maximum fees it is
   prepared to pay for a close transaction.
+  - if it doesn't receive a `closing_signed` response after a reasonable amount of time:
+    - MUST fail the channel
   - if it is not the funder:
     - SHOULD set `max_fee_satoshis` to at least the `max_fee_satoshis` received
 	  - SHOULD set `min_fee_satoshis` to a fairly low value
@@ -603,16 +605,17 @@ The receiving node:
   - if the message contains a `fee_range`:
     - if there is no overlap between that and its own `fee_range`:
       - SHOULD send a `warning`
+      - MUST fail the channel if it doesn't receive a satisfying `fee_range` after a reasonable amount of time
     - otherwise:
       - if it is the funder:
         - if `fee_satoshis` is not in the overlap between the sent and received `fee_range`:
-          - SHOULD send a `warning`
+          - MUST fail the channel
         - otherwise:
           - MUST reply with the same `fee_satoshis`.
       - otherwise (it is not the funder):
         - if it has already sent a `closing_signed`:
           - if `fee_satoshis` is not the same as the value it sent:
-            - SHOULD send a `warning`
+            - MUST fail the channel
         - otherwise:
           - MUST propose a `fee_satoshis` in the overlap between received and (about-to-be) sent `fee_range`.
   - otherwise, if `fee_satoshis` is not strictly between its last-sent `fee_satoshis`

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -609,17 +609,17 @@ The receiving node:
     - MUST fail the connection.
   - if the message contains a `fee_range`:
     - if there is no overlap between that and its own `fee_range`:
-      - SHOULD fail the connection
+      - SHOULD send a `warning`
     - otherwise:
       - if it is the funder:
         - if `fee_satoshis` is not in the overlap between the sent and received `fee_range`:
-          - SHOULD fail the connection
+          - SHOULD send a `warning`
         - otherwise:
           - MUST reply with the same `fee_satoshis`.
       - otherwise (it is not the funder):
         - if it has already sent a `closing_signed`:
           - if `fee_satoshis` is not the same as the value it sent:
-            - SHOULD fail the connection.
+            - SHOULD send a `warning`
         - otherwise:
           - MUST propose a `fee_satoshis` in the overlap between received and (about-to-be) sent `fee_range`.
   - otherwise, if `fee_satoshis` is not strictly between its last-sent `fee_satoshis`

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -554,9 +554,9 @@ exchange continues until both agree on the same fee or when one side fails
 the channel.
 
 In the modern method, the funder sends its permissable fee range, and the
-non-funder has to pick a fee in this range. If it chooses the same value,
-negotiation is complete after two messages, otherwise the funder will reply
-with the same value (completing after three messages).
+non-funder has to pick a fee in this range. If the non-funder chooses the same
+value, negotiation is complete after two messages, otherwise the funder will
+reply with the same value (completing after three messages).
 
 1. type: 39 (`closing_signed`)
 2. data:
@@ -604,7 +604,7 @@ The receiving node:
     - MAY close the connection.
   - if the message contains a `fee_range`:
     - if there is no overlap between that and its own `fee_range`:
-      - SHOULD send a `warning`
+      - SHOULD fail the connection
       - MUST fail the channel if it doesn't receive a satisfying `fee_range` after a reasonable amount of time
     - otherwise:
       - if it is the funder:


### PR DESCRIPTION
With anchor outputs, we can keep the commit tx feerate lower than the real on-chain feerate.

That means that when closing the channel, the closing fee will not necessarily be lower than the current commit tx fee, the existing requirement doesn't make sense to be that strict (at least for anchor outputs).

Imagine for example that the commitment feerate is kept at 10 sat/byte (what lnd currently does when using anchor outputs).
Imagine you want to do a mutual close on that channel and target a confirmation in N blocks, which results in a feerate higher than 10 sat/byte.
That's perfectly reasonable and should be allowed, otherwise you have no way of negotiating a feerate higher than 10 sat/byte (which may confirm in weeks if the mempool is quite full, like it is nowadays).