### PR TITLE
Add keysend invoice

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -7,6 +7,7 @@ over Lightning.
 
   * [Encoding Overview](#encoding-overview)
   * [Human-Readable Part](#human-readable-part)
+  * [Keysend Invoice Overview](#keysend-invoice-overview)
   * [Data Part](#data-part)
     * [Tagged Fields](#tagged-fields)
     * [Feature Bits](#feature-bits)
@@ -59,6 +60,15 @@ The following `multiplier` letters are defined:
 * `u` (micro): multiply by 0.000001
 * `n` (nano): multiply by 0.000000001
 * `p` (pico): multiply by 0.000000000001
+
+# Keysend Invoice Overview
+
+Keysend invoice is a subset of standard invoice with the following differences: 
+- prefix is set to `lnks` + BIP-0173 currency prefix (e.g. `lnksbc` for Bitcoin mainnet,
+   `lnkstb` for Bitcoin testnet, `lnkstbs` for Bitcoin signet, and `lnksbcrt` for
+   Bitcoin regtest).
+- `p` tagged field MUST NOT be included.
+- `amount` and `multiplier` MUST NOT be included.
 
 ## Requirements
 


### PR DESCRIPTION
This adds a new type of invoice tailored specifically for keysend payments, it complements keysend scheme outlined at https://github.com/alexbosworth/keysend_protocols#keysend-protocol-2-basic-messages.

The idea is:
1. Routing hints are handled in a standard way so keysend invoice issuer may be a mobile wallet user with private channels only.
2. `lnks` prefix prevents it from being wrongly categorized as usual invoice (and failed since it does not contain a payment hash field which is required for usual invoices).
3. `5482373481` onion TLV field contents `(32 Byte Predetermined Id for Grouping Messages)` will be a payment secret tag provided by payee beforehand in keysend invoice. This will allow payee wallet to group different incoming payments belonging to the same keysend invoice.