### PR TITLE
BOLT 4: remove space in formatting which prevented tools/extract-formats.py

### DIFF
--- a/04-onion-routing.md
+++ b/04-onion-routing.md
@@ -989,7 +989,7 @@ The amount in the HTLC doesn't match the value in the onion.
 
 1. type: UPDATE|20 (`channel_disabled`)
 2. data:
-   * [`u16`: `flags`]
+   * [`u16`:`flags`]
    * [`u16`:`len`]
    * [`len*byte`:`channel_update`]
 


### PR DESCRIPTION
As seen in https://github.com/lightningnetwork/lightning-rfc/issues/791!

This is the only one, so I simply removed it.  We'd notice if a new field
was introduced which didn't change the output these days, but this has been
here since 2017.

Here's the difference in extract-formats.py's output:

```diff
@@ -177,6 +177,9 @@
 msgtype,final_incorrect_htlc_amount,19
 msgdata,final_incorrect_htlc_amount,incoming_htlc_amt,u64,
 msgtype,channel_disabled,UPDATE|20
+msgdata,channel_disabled,flags,u16,
+msgdata,channel_disabled,len,u16,
+msgdata,channel_disabled,channel_update,byte,len
 msgtype,expiry_too_far,21
 msgtype,invalid_onion_payload,PERM|22
 msgdata,invalid_onion_payload,type,bigsize,
```

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>