### PR TITLE
Peer backup storage (feature 36/37)

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -40,7 +40,8 @@ The Context column decodes as follows:
 | 18/19 | `option_support_large_channel`   | Can create large channels                                 | IN       |                   | [BOLT #2](02-peer-protocol.md#the-open_channel-message) |
 | 20/21 | `option_anchor_outputs`          | Anchor outputs                                            | IN       | `option_static_remotekey` | [BOLT #3](03-transactions.md)         |
 | 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
-| 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`              | IN       |                   | [BOLT #2][bolt02-shutdown]   |
+| 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`           | IN       |                   | [BOLT #2][bolt02-shutdown]   |
+| 36/37 | `peer_backup_storage`               | Allow storing encrypted peer backup data               | IN       |                   | [BOLT #2][bolt02-peer-backup]   |
 
 ## Requirements
 
@@ -84,6 +85,7 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 [bolt02-open]: 02-peer-protocol.md#the-open_channel-message
 [bolt03-htlc-tx]: 03-transactions.md#htlc-timeout-and-htlc-success-transactions
 [bolt02-shutdown]: 02-peer-protocol.md#closing-initiation-shutdown
+[bolt02-peer-backup]: 02-peer-protocol.md#peer-backup-storage
 [bolt04]: 04-onion-routing.md
 [bolt07-sync]: 07-routing-gossip.md#initial-sync
 [bolt07-query]: 07-routing-gossip.md#query-messages


### PR DESCRIPTION
Nodes can offer to altruistically store small amounts of data on behalf of their channel peers.
It complements `option_data_loss_protect` and can let nodes that lost data fully recover their channels without any on-chain transaction.

The contents of the `peer_backup` is left unspecified to offer wide flexibility for implementations. It can for example contain an encrypted version of your internal channel state, or a mix of data from several channels (if you want to shard your backups across multiple nodes to maximize your chances of recovery).

The version we currently use for Phoenix only needs to send a `peer_backup` in messages that change the channel state, but maybe we want to extend this optional TLV and include it in more messages? Do you see use-cases where that would be useful?