### PR TITLE
Feature `option_scid_alias` separate from zero-conf

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -41,6 +41,7 @@ The Context column decodes as follows:
 | 20/21 | `option_anchor_outputs`          | Anchor outputs                                            | IN       | `option_static_remotekey` | [BOLT #3](03-transactions.md)         |
 | 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
 | 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`              | IN       |                   | [BOLT #2][bolt02-shutdown]   |
+| 46/47 | `option_scid_alias`| Supports channel aliases for routing                  | IN       |                   | [BOLT #2][bolt02-funding-locked]   |
 
 ## Requirements
 
@@ -84,6 +85,7 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 [bolt02-open]: 02-peer-protocol.md#the-open_channel-message
 [bolt03-htlc-tx]: 03-transactions.md#htlc-timeout-and-htlc-success-transactions
 [bolt02-shutdown]: 02-peer-protocol.md#closing-initiation-shutdown
+[bolt02-funding-locked]: 02-peer-protocol.md#the-funding_locked-message
 [bolt04]: 04-onion-routing.md
 [bolt07-sync]: 07-routing-gossip.md#initial-sync
 [bolt07-query]: 07-routing-gossip.md#query-messages


### PR DESCRIPTION
This is an alternative to https://github.com/lightningnetwork/lightning-rfc/pull/910, it is very close with the following changes:

- make zero-conf and `scid` `alias` independent
Fundee may signal that it is willing to trust the funder by setting `minimum_depth` to zero, but that's unenforceable anyway.

- make `scid` `alias` and channel announcement independent
There is no reason to advertize the "real" `scid` in `funding_locked`, because the real `scid` is already provided in `announcement_signatures`

- have nodes only advertise their ability to understand `scid` `alias` (feature `option_scid_alias`)
If this feature is negotiated (both peers support it), then they must only use `alias`es (but that's unenforceable).

- accept that some combinations don't make sense, like "zero-conf without alias", or "alias and public channels"