### PR TITLE
Remove link to lightning.network website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Lightning Network](https://lightning.network) In-Progress Specifications
+# Lightning Network In-Progress Specifications
 
 The specifications are currently a work-in-progress and currently being
 drafted.


### PR DESCRIPTION
None of the project maintainers have access to that website.
It is completely outdated and could be modified without our consent, so we shouldn't link to it anymore.
Unless @josephpoon agrees to give us access?