### PR TITLE
Make Markdown linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Before this change, repository gets detected as:

Python 51.1%
Shell 48.9%

After this change, repository gets detected as:

Markdown 98.0%
Other 2.0%

This change was added for a cosmetic effect on GitHub, and the line
this change adds can go away in any of these cases:

* Conflict with other tool used for reading these documents.

* GitHub ceases to use the line.

* GitHub ceases to be used as a reading medium for these documents.

* GitHub ceases to exist.

---

See also: pull request 1203 in bitcoin/bips.
