### PR TITLE
Remove explicit 6-blocks delay for `announcement_signatures`

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -84,8 +84,8 @@ The `announcement_signatures` message is created by constructing a `channel_anno
 A node:
   - if the `open_channel` message has the `announce_channel` bit set AND a `shutdown` message has not been sent:
     - MUST send the `announcement_signatures` message.
-      - MUST NOT send `announcement_signatures` messages until `channel_ready`
-      has been sent and received AND the funding transaction has at least six confirmations.
+      - MUST NOT send `announcement_signatures` until `channel_ready` has been sent and received.
+      - MUST NOT send `announcement_signatures` until the funding transaction has enough confirmations to ensure that it won't be reorganized.
   - otherwise:
     - MUST NOT send the `announcement_signatures` message.
   - upon reconnection (once the above timing requirements have been met):
@@ -104,10 +104,9 @@ A recipient node:
   - if it has sent AND received a valid `announcement_signatures` message:
     - SHOULD queue the `channel_announcement` message for its peers.
   - if it has not sent `channel_ready`:
-    - MAY defer handling the announcement_signatures until after it has sent `channel_ready`
+    - MAY defer handling the `announcement_signatures` until after it has sent `channel_ready`.
     - otherwise:
       - MUST ignore it.
-
 
 ### Rationale
 
@@ -115,6 +114,10 @@ The reason for allowing deferring of a premature announcement_signatures is
 that an earlier version of the spec did not require waiting for receipt of
 funding locked: deferring rather than ignoring it allows compatibility with
 this behavior.
+
+Channels must not be announced before the funding transaction has enough
+confirmations, because a blockchain reorganization would otherwise invalidate
+the `short_channel_id`.
 
 ## The `channel_announcement` Message
 


### PR DESCRIPTION
We previously required waiting for 6 confirmations before sending `announcement_signatures`, but the real criteria is that it should only be sent once you are confident that a reorg will not invalidate it.

Most nodes only wait for 3 confirmations before sending `channel_ready`, which means that they are confident that a malicious 3-blocks reorg will not happen, otherwise their peer may steal the entire channel amount. If they're ready to put their own money at stake after 3 confirmations, then they're also ready to announce the channel after 3 confirmations, right?

In eclair we scale the number of confirmations with the size of the channel, with a minimum amount of 3 confirmations for small channels. I believe that every implementation should do something similar, in which case we don't need this explicit 6-blocks delay? For context, I'm trying to simplify our code in preparation for announcing splices, and it's much simpler to rely only on the number of confirmations we feel safe with than mixing it with a separate 6-blocks delay for announcements.

What implementations should check before ack-ing this PR:

- how they behave when receiving `announcement_signatures` too early: they should stash it and replay it once the funding tx has reached enough confirmations
- how they behave when receiving `channel_announcement` before 6-confirmations: IMO the channel should be added to the routing graph as long as it's confirmed and unspent, and we should simply watch for it to be spent or reorg-ed (which is already what the spec mandates)