### PR TITLE
Add test vector for (invalid) mixed-case offer encoding

### DIFF
--- a/bolt12/format-string-test.json
+++ b/bolt12/format-string-test.json
@@ -30,6 +30,11 @@
 	"string": "LNO1PQPS7SJQPGT+ YZM3QV4UXZMTSD3JJQER9WD3HY6TSW3+  5K7MSJZFPY7NZ5YQCN+\nYGRFDEJ82UM5WF5K2UCKYYPWA3EYT44H6TXTXQUQH7LZ5DJGE4AFGFJN7K4RGRKUAG0JSD+\r\n 5XVXG"
     },
     {
+	"comment": "Mixed case is invalid",
+	"valid": false,
+	"string": "LnO1PqPs7sJqPgTyZm3qV4UxZmTsD3JjQeR9Wd3hY6TsW35k7mSjZfPy7nZ5YqCnYgRfDeJ82uM5Wf5k2uCkYyPwA3EyT44h6tXtXqUqH7Lz5dJgE4AfGfJn7k4rGrKuAg0jSd5xVxG"
+    },
+    {
 	"comment": "+ must be surrounded by bech32 characters",
 	"valid": false,
 	"string": "lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfpy7nz5yqcnygrfdej82um5wf5k2uckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg+"


### PR DESCRIPTION
The spec requires the bech32 offer encodings to be all upper- or lowercase, but disallows mixed-case encodings.

Here, we add a test vector checking for this.