### PR TITLE
Require minimally-encoded features in BOLT 11 invoices

### DIFF
--- a/11-payment-encoding.md
+++ b/11-payment-encoding.md
@@ -98,6 +98,9 @@ whatever is being offered in return.
 The `p` multiplier would allow to specify sub-millisatoshi amounts, which cannot be transferred on the network, since HTLCs are denominated in millisatoshis.
 Requiring a trailing `0` decimal ensures that the `amount` represents an integer number of millisatoshis.
 
+Note that non-largest multipliers have been encountered in the wild, and as
+such invoice parsers should handle them.
+
 # Data Part
 
 The data part of a Lightning invoice consists of multiple sections:


### PR DESCRIPTION
When decoding BOLT 11 invoices, LDK has always read them into fields, parsing what it can. When parsing features, this loses the information on the number of field elements which were used to encode the features in the invoice itself.

When we then go to calculate a hash of the invoice for signature validation/key recovery, we go re-serialize the invoice. At this point, any excess field elements used to encode features will be lost and the invoice's hash will be different from what the original encoder intended.

Luckily, this doesn't appear to have ever happened in practice. This was, in fact, only found by @erickcestari, @brunoerg, and @morehouse when doing differential fuzzing.

Because this hasn't happened and it breaks a straightforward way to handle BOLT 11 parsing, there's no reason to retain it, so instead here we simply forbid non-minimally-encoded features in BOLT 11 invoices.

See https://github.com/lightningdevkit/rust-lightning/issues/3693 for the specific example generated by fuzzing.