### PR TITLE
Update "invalid currency UTF-8" test vector 

### DIFF
--- a/bolt12/offers-test.json
+++ b/bolt12/offers-test.json
@@ -491,7 +491,7 @@
   {
     "description": "Malformed: invalid currency UTF-8",
     "valid": false,
-    "bolt12": "lno1qcpgqsg2q4q5cj2rg5tzzqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqg"
+    "bolt12": "lno1qcplllhapqpq86q2q4qkc6trv5tzzq6muh550qsfva9fdes0ruph7ctk2s8aqq06r4jxj3msc448wzwy9s"
   },
   {
     "description": "Malformed: truncated description UTF-8",


### PR DESCRIPTION
This PR updates the "Malformed: invalid currency UTF-8" test vector to use 3 bytes of invalid UTF-8 instead of 2 bytes, since some applications like rust-lightning only validate encoding/size with proper length encoding (03 length with 3-byte value).

This commit replaces it with a test vector that:
- Uses length encoding (03 length with 3-byte of invalid UTF-8)  