### PR TITLE
Increase channel close delay to 72 blocks

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -228,7 +228,7 @@ The receiving node:
         - SHOULD store this `channel_announcement`.
   - once its funding output has been spent OR reorganized out:
     - SHOULD forget a channel after a 72-block delay.
-    - MUST NOT rebroadcast this `channel_announcement` to its peers.
+    - SHOULD NOT rebroadcast this `channel_announcement` to its peers.
 
 ### Rationale
 
@@ -510,7 +510,7 @@ The receiving node:
     channels.
   - if the channel output has been spent:
     - MUST ignore `channel_update`s, unless they have the `disable` bit set to 1.
-    - MUST NOT rebroadcast `channel_update`s to its peers, unless they have the
+    - SHOULD NOT rebroadcast `channel_update`s to its peers, unless they have the
     `disable` bit set to 1.
   - SHOULD accept `channel_update`s for its own channels (even if non-public),
   in order to learn the associated origin nodes' forwarding parameters.
@@ -875,7 +875,7 @@ The receiver:
   - If a `channel_announcement` has no corresponding `channel_update`s:
     - MUST NOT send the `channel_announcement`.
   - If the funding output of the `channel_announcement` has been spent:
-    - MUST NOT send the `channel_announcement`.
+    - SHOULD NOT send the `channel_announcement`.
   - Otherwise:
     - MUST consider the `timestamp` of the `channel_announcement` to be the `timestamp` of a corresponding `channel_update`.
     - MUST consider whether to send the `channel_announcement` after receiving the first corresponding `channel_update`.


### PR DESCRIPTION
In #1044, we introduced a 12-blocks delay before considering a channel closed when we see a spending confirmation on-chain. This ensures that if the channel was spliced instead of closed, the channel participants are able to broadcast a new `channel_announcement` to the rest of the network. If this new `channel_announcement` is received by renote nodes before the 12-blocks delay, the channel can keep its history in path finding scoring/reputation, which is important.

We then realize that 12 blocks probably wasn't enough to allow this to happen: some implementations default to 8 confirmations before sending `splice_locked`, and allow node operators to increase this value. We thus bump this delay to 72 blocks to allow more time before channels are removed from the local graph.

We also add requirements in the 2nd commit to avoid rebroadcasting announcement for spent channels, because our peers may otherwise think we're trying to spam them.