### PR TITLE
Explicit `commit_sig` retransmission for `interactive-tx`

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -2742,7 +2742,7 @@ A node:
     - MUST reuse the same commitment number for its next `commitment_signed`.
   - otherwise:
     - if `next_commitment_number` is not equal to the commitment number of the
-      next `commitment_signed` the receiving node would send:
+      next `commitment_signed` that the receiving node would send:
       - SHOULD send an `error` and fail the channel.
   - if `next_revocation_number` is equal to the commitment number of
   the last `revoke_and_ack` the receiving node sent, AND the receiving node


### PR DESCRIPTION
When disconnecting in the middle of the signing steps of an `interactive-tx` transaction, we must retransmit signatures on reconnection to complete the `interactive-tx` protocol.

Nodes first exchange `commitment_signed`, followed by `tx_signatures` once they have both sent and received `commitment_signed`.

We previously always retransmitted `commitment_signed`, even when our peer had already received it. We now include an explicit bitfield that lets nodes request `commitment_signed` if they haven't received it.

Note that this is a breaking change, and we are thus changing the TLV type to make it easier to detect. In practice it should be fine, since only `eclair` and `cln` have shipped support for dual funding, and those two implementations are already incompatible on reconnection because `eclair` implements #1214 but `cln` doesn't. This edge case only creates an issue when nodes disconnect after exchanging `tx_complete` but before receiving signatures, which should happen very infrequently.

Replaces #1214.