### PR TITLE
Remove ambiguous note about use of `localpubkey` in `to_remote`

### DIFF
--- a/03-transactions.md
+++ b/03-transactions.md
@@ -1035,8 +1035,8 @@ The *expected weight* of an HTLC transaction is calculated as follows:
         - OP_IF: 1 byte
         - OP_CHECKSIG: 1 byte
         - OP_ELSE: 1 byte
-        - OP_DATA: 1 byte (remotepubkey length)
-        - remotepubkey: 33 bytes
+        - OP_DATA: 1 byte (remote_htlcpubkey length)
+        - remote_htlcpubkey: 33 bytes
         - OP_SWAP: 1 byte
         - OP_SIZE: 1 byte
         - OP_DATA: 1 byte (32 length)
@@ -1049,8 +1049,8 @@ The *expected weight* of an HTLC transaction is calculated as follows:
         - OP_EQUALVERIFY: 1 byte
         - 2: 1 byte
         - OP_SWAP: 1 byte
-		- OP_DATA: 1 byte (localpubkey length)
-		- localpubkey: 33 bytes
+		- OP_DATA: 1 byte (local_htlcpubkey length)
+		- local_htlcpubkey: 33 bytes
         - 2: 1 byte
         - OP_CHECKMULTISIG: 1 byte
         - OP_ELSE: 1 byte
@@ -1075,8 +1075,8 @@ The *expected weight* of an HTLC transaction is calculated as follows:
         - OP_IF: 1 byte
         - OP_CHECKSIG: 1 byte
         - OP_ELSE: 1 byte
-		- OP_DATA: 1 byte (remotepubkey length)
-		- remotepubkey: 33 bytes
+		- OP_DATA: 1 byte (remote_htlcpubkey length)
+		- remote_htlcpubkey: 33 bytes
 		- OP_SWAP: 1 byte
 		- OP_SIZE: 1 byte
 		- OP_DATA: 1 byte (32 length)
@@ -1086,8 +1086,8 @@ The *expected weight* of an HTLC transaction is calculated as follows:
 		- OP_DROP: 1 byte
 		- 2: 1 byte
 		- OP_SWAP: 1 byte
-		- OP_DATA: 1 byte (localpubkey length)
-		- localpubkey: 33 bytes
+		- OP_DATA: 1 byte (local_htlcpubkey length)
+		- local_htlcpubkey: 33 bytes
 		- 2: 1 byte
 		- OP_CHECKMULTISIG: 1 byte
 		- OP_ELSE: 1 byte


### PR DESCRIPTION
* Remove ambiguous note about `localpubkey` being used in `to_remote`
* While we're here, use proper htlc pubkey names in expected weights section (rather than overloading `{local/remote}pubkey`