### PR TITLE
BOLT 12: clarify that offer_amount must be greater than zero

### DIFF
--- a/12-offer-encoding.md
+++ b/12-offer-encoding.md
@@ -240,6 +240,7 @@ A writer of an offer:
     - SHOULD omit `offer_chains`, implying that bitcoin is only chain.
   - if a specific minimum `offer_amount` is required for successful payment:
     - MUST set `offer_amount` to the amount expected (per item).
+    - MUST set `offer_amount` greater than zero.
     - if the currency for `offer_amount` is that of all entries in `chains`:
       - MUST specify `offer_amount` in multiples of the minimum lightning-payable unit
         (e.g. milli-satoshis for bitcoin).
@@ -298,6 +299,8 @@ A reader of an offer:
     - if the node does not accept invoices for at least one of the `chains`:
       - MUST NOT respond to the offer
   - if `offer_amount` is set and `offer_description` is not set:
+    - MUST NOT respond to the offer.
+  - if `offer_amount` is set and is not greater than zero:
     - MUST NOT respond to the offer.
   - if `offer_currency` is set and `offer_amount` is not set:
     - MUST NOT respond to the offer.

--- a/bolt12/offers-test.json
+++ b/bolt12/offers-test.json
@@ -579,6 +579,57 @@
     "bolt12": "lno1qcp4256ypgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg"
   },
   {
+    "description": "Invalid: zero offer_amount",
+    "valid": false,
+    "bolt12": "lno1pqqq5qqkyyp4he0fg7pqje62jmnq78cr0ashv4q06qql58tyd9rhp3t2wuyugtq",
+    "field info": "offer_amount is 0",
+    "fields": [
+      {
+        "type": 8,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 10,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 22,
+        "length": 33,
+        "hex": "035be5e9478209674a96e60f1f037f6176540fd001fa1d64694770c56a7709c42c"
+      }
+    ]
+  },
+  {
+    "description": "Invalid: zero offer_amount with currency",
+    "valid": false,
+    "bolt12": "lno1qcp4256ypqqq5qqkyyp4he0fg7pqje62jmnq78cr0ashv4q06qql58tyd9rhp3t2wuyugtq",
+    "field info": "offer_amount is 0, offer_currency is USD",
+    "fields": [
+      {
+        "type": 6,
+        "length": 3,
+        "hex": "555344"
+      },
+      {
+        "type": 8,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 10,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 22,
+        "length": 33,
+        "hex": "035be5e9478209674a96e60f1f037f6176540fd001fa1d64694770c56a7709c42c"
+      }
+    ]
+  },
+  {
     "description": "Missing offer_issuer_id and no offer_path",
     "valid": false,
     "bolt12": "lno1pgx9getnwss8vetrw3hhyuc"


### PR DESCRIPTION
Add explicit requirements that:
- Writers MUST set offer_amount greater than zero when present
- Readers MUST NOT respond to offers where offer_amount is zero

This addresses ambiguity about whether offer_amount=0 is valid. Since omitting offer_amount indicates no minimum is required, a zero value when present would be semantically incorrect.

Fixes #1314