### PR TITLE
BOLT 7: port zero always bad.

### DIFF
--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -342,8 +342,7 @@ The origin node:
   - MUST place address descriptors in ascending order.
   - SHOULD NOT place any zero-typed address descriptors anywhere.
   - SHOULD use placement only for aligning fields that follow `addresses`.
-  - MUST NOT create a `type 1`, `type 2` or `type 5` address descriptor with
-  `port` equal to 0.
+  - MUST NOT create an address descriptor with `port` equal to 0.
   - SHOULD ensure `ipv4_addr` AND `ipv6_addr` are routable addresses.
   - MUST set `features` according to [BOLT #9](09-features.md#assigned-features-flags)
   - SHOULD set `flen` to the minimum length required to hold the `features`
@@ -374,7 +373,7 @@ any future fields appended to the end):
     - SHOULD send a `warning`.
     - MAY close the connection.
   - if `port` is equal to 0:
-    - SHOULD ignore `ipv6_addr` OR `ipv4_addr` OR `hostname`.
+    - SHOULD ignore that address descriptor.
   - if `node_id` is NOT previously known from a `channel_announcement` message,
   OR if `timestamp` is NOT greater than the last-received `node_announcement`
   from this `node_id`:


### PR DESCRIPTION
This language dates back to when there were only IPv4 and v6 descriptors. DNS got added with that change, but Tor was never updated.

Zero ports never make sense, always disallow.  I assume everyone does this.